### PR TITLE
fix: fix failed weakref in connect_setattr

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,7 +161,7 @@ jobs:
           python-version: "3.9"
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.11.1
+        uses: pypa/cibuildwheel@v2.11.2
 
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,7 +135,7 @@ jobs:
 
       - uses: actions/checkout@v3
         with:
-          repository: napari/magicgui
+          repository: pyapp-kit/magicgui
           path: magicgui
 
       - uses: actions/setup-python@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -219,7 +219,7 @@ build_command = "pip install build && python -m build"
 
 [tool.cibuildwheel]
 # Skip 32-bit builds & PyPy wheels on all platforms
-skip = ["*-win32", "pp*", "cp311*"]
+skip = ["*-win32", "pp*"]
 test-extras = ["test"]
 test-command = "pytest {project}/tests -v"
 test-skip = "*-musllinux* *-manylinux_i686"

--- a/tests/test_psygnal.py
+++ b/tests/test_psygnal.py
@@ -721,8 +721,9 @@ def test_connect_setitem():
     assert my_obj._dict == {"x": 5}
 
     obj = object()
-    with pytest.raises(TypeError, match="does not support __setitem__"):
-        t.sig.connect_setitem(obj, "x")
+    with pytest.warns(RuntimeWarning):
+        with pytest.raises(TypeError, match="does not support __setitem__"):
+            t.sig.connect_setitem(obj, "x")
 
     with pytest.raises(ValueError):
         t.sig.disconnect_setitem(obj, "x", missing_ok=False)


### PR DESCRIPTION
this catches failed weakref.ref() calls in connect_setattr, just like the ones in `connect_setitem` ... and adds a warning in both cases