### PR TITLE
build: don't compile group

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,7 +92,7 @@ sources = ["src"]
 enable-by-default = false
 require-runtime-dependencies = true
 dependencies = ["hatch-mypyc>=0.13.0", "mypy>=0.991", "pydantic", "types-attrs"]
-include = ["src/psygnal/_signal.py", "src/psygnal/_group.py"]
+include = ["src/psygnal/_signal.py"]
 
 [tool.cibuildwheel]
 # Skip 32-bit builds & PyPy wheels on all platforms

--- a/src/psygnal/_signal.py
+++ b/src/psygnal/_signal.py
@@ -858,8 +858,12 @@ class SignalInstance:
 
         return None
 
-    def block(self) -> None:
-        """Block this signal from emitting."""
+    def block(self, exclude: Iterable[str | SignalInstance] = ()) -> None:
+        """Block this signal from emitting.
+
+        NOTE: the `exclude` argument is only for SignalGroup subclass, but we
+        have to include it here to make mypyc happy.
+        """
         self._is_blocked = True
 
     def unblock(self) -> None:
@@ -1006,13 +1010,7 @@ class _SignalBlocker:
         self._exclude = exclude
 
     def __enter__(self) -> None:
-        from ._group import SignalGroup
-
-        if isinstance(self._signal, SignalGroup):
-            self._signal.block(exclude=self._exclude)
-        else:
-            self._signal.block()
-        return None
+        self._signal.block(exclude=self._exclude)
 
     def __exit__(self, *args: Any) -> None:
         self._signal.unblock()


### PR DESCRIPTION
compiling SignalGroup with mypyc is much more problematic than Signal due to the dynamic nature of attribute access there.  It's also much less performance critical.  so not compiling here for now (after seeing the unexpected error in #150) 