### PR TITLE
fix: add dataclass_transform to maintain IDE typing support for EventedModel.__init__

### DIFF
--- a/src/psygnal/_evented_model.py
+++ b/src/psygnal/_evented_model.py
@@ -80,7 +80,7 @@ def no_class_attributes() -> Iterator[None]:  # pragma: no cover
 
     # monkey patch the pydantic ClassAttribute object
     # the second argument to ClassAttribute is the inspect.Signature object
-    def _return2(x: str, y: 'Signature') -> 'Signature':
+    def _return2(x: str, y: "Signature") -> "Signature":
         return y
 
     pydantic.main.ClassAttribute = _return2  # type: ignore

--- a/src/psygnal/_evented_model.py
+++ b/src/psygnal/_evented_model.py
@@ -8,17 +8,15 @@ from typing import (
     Any,
     Callable,
     ClassVar,
-    Dict,
     Iterator,
-    Set,
     Type,
-    Union,
     cast,
     no_type_check,
 )
 
 import pydantic.main
 from pydantic import BaseModel, PrivateAttr, utils
+from pydantic.fields import Field, FieldInfo
 
 from ._evented_decorator import _check_field_equality, _pick_equality_operator
 from ._group import SignalGroup
@@ -29,9 +27,18 @@ if TYPE_CHECKING:
 
     from pydantic import BaseConfig
     from pydantic.fields import ModelField
+    from typing_extensions import dataclass_transform
 
     ConfigType = Type[BaseConfig]
     EqOperator = Callable[[Any, Any], bool]
+
+else:
+    try:
+        from typing_extensions import dataclass_transform
+    except ImportError:
+
+        def dataclass_transform(*args, **kwargs):
+            return lambda a: a
 
 _NULL = object()
 ALLOW_PROPERTY_SETTERS = "allow_property_setters"
@@ -84,6 +91,7 @@ def no_class_attributes() -> Iterator[None]:  # pragma: no cover
         pydantic.main.ClassAttribute = utils.ClassAttribute  # type: ignore
 
 
+@dataclass_transform(kw_only_default=True, field_descriptors=(Field, FieldInfo))
 class EventedMetaclass(pydantic.main.ModelMetaclass):
     """pydantic ModelMetaclass that preps "equality checking" operations.
 
@@ -108,7 +116,7 @@ class EventedMetaclass(pydantic.main.ModelMetaclass):
 
         cls.__eq_operators__ = {}
         signals = {}
-        fields: Dict[str, ModelField] = cls.__fields__
+        fields: dict[str, ModelField] = cls.__fields__
         for n, f in fields.items():
             cls.__eq_operators__[n] = _pick_equality_operator(f.type_)
             if f.field_info.allow_mutation:
@@ -153,7 +161,7 @@ class EventedMetaclass(pydantic.main.ModelMetaclass):
         return cls
 
 
-def _get_field_dependents(cls: EventedModel) -> Dict[str, Set[str]]:  # noqa: C901
+def _get_field_dependents(cls: EventedModel) -> dict[str, set[str]]:  # noqa: C901
     """Return mapping of field name -> dependent set of property names.
 
     Dependencies may be declared in the Model Config to emit an event
@@ -177,7 +185,7 @@ def _get_field_dependents(cls: EventedModel) -> Dict[str, Set[str]]:  # noqa: C9
             class Config:
                 property_dependencies={'c': ['a', 'b']}
     """
-    deps: Dict[str, Set[str]] = {}
+    deps: dict[str, set[str]] = {}
 
     cfg_deps = getattr(cls.__config__, PROPERTY_DEPENDENCIES, {})  # sourcery skip
     if cfg_deps:
@@ -291,13 +299,13 @@ class EventedModel(BaseModel, metaclass=EventedMetaclass):
     _events: SignalGroup = PrivateAttr()
 
     # mapping of name -> property obj for methods that are property setters
-    __property_setters__: ClassVar[Dict[str, property]]
+    __property_setters__: ClassVar[dict[str, property]]
     # mapping of field name -> dependent set of property names
     # when field is changed, an event for dependent properties will be emitted.
-    __field_dependents__: ClassVar[Dict[str, Set[str]]]
-    __eq_operators__: ClassVar[Dict[str, EqOperator]]
+    __field_dependents__: ClassVar[dict[str, set[str]]]
+    __eq_operators__: ClassVar[dict[str, EqOperator]]
     __slots__ = {"__weakref__"}
-    __signal_group__: ClassVar[Type[SignalGroup]]
+    __signal_group__: ClassVar[type[SignalGroup]]
     # pydantic BaseModel configuration.  see:
     # https://pydantic-docs.helpmanual.io/usage/model_config/
 
@@ -365,7 +373,7 @@ class EventedModel(BaseModel, metaclass=EventedMetaclass):
             ):
                 setattr(self, name, value)
 
-    def update(self, values: Union[EventedModel, dict], recurse: bool = True) -> None:
+    def update(self, values: EventedModel | dict, recurse: bool = True) -> None:
         """Update a model in place.
 
         Parameters
@@ -434,7 +442,7 @@ class EventedModel(BaseModel, metaclass=EventedMetaclass):
                 delattr(self.Config, "use_enum_values")
 
 
-def _get_defaults(obj: BaseModel) -> Dict[str, Any]:
+def _get_defaults(obj: BaseModel) -> dict[str, Any]:
     """Get possibly nested default values for a Model object."""
     dflt = {}
     for k, v in obj.__fields__.items():

--- a/src/psygnal/_evented_model.py
+++ b/src/psygnal/_evented_model.py
@@ -24,7 +24,7 @@ from ._group import SignalGroup
 from ._signal import Signal, SignalInstance
 
 if TYPE_CHECKING:
-    import inspect
+    from inspect import Signature
 
     from pydantic.fields import ModelField
     from typing_extensions import dataclass_transform
@@ -80,7 +80,7 @@ def no_class_attributes() -> Iterator[None]:  # pragma: no cover
 
     # monkey patch the pydantic ClassAttribute object
     # the second argument to ClassAttribute is the inspect.Signature object
-    def _return2(x: str, y: inspect.Signature) -> inspect.Signature:
+    def _return2(x: str, y: 'Signature') -> 'Signature':
         return y
 
     pydantic.main.ClassAttribute = _return2  # type: ignore

--- a/src/psygnal/_evented_model.py
+++ b/src/psygnal/_evented_model.py
@@ -34,7 +34,7 @@ if TYPE_CHECKING:
 else:
     try:
         from typing_extensions import dataclass_transform
-    except ImportError:
+    except ImportError:  # pragma: no cover
 
         def dataclass_transform(*args, **kwargs):
             return lambda a: a

--- a/src/psygnal/_evented_model.py
+++ b/src/psygnal/_evented_model.py
@@ -116,7 +116,7 @@ class EventedMetaclass(pydantic.main.ModelMetaclass):
 
         cls.__eq_operators__ = {}
         signals = {}
-        fields: Dict[str, 'ModelField'] = cls.__fields__
+        fields: Dict[str, "ModelField"] = cls.__fields__
         for n, f in fields.items():
             cls.__eq_operators__[n] = _pick_equality_operator(f.type_)
             if f.field_info.allow_mutation:
@@ -315,7 +315,11 @@ class EventedModel(BaseModel, metaclass=EventedMetaclass):
 
     def __init__(_model_self_, **data: Any) -> None:
         super().__init__(**data)
-        _model_self_._events = _model_self_.__signal_group__(_model_self_)
+        Group = _model_self_.__signal_group__
+        # the type error is "cannot assign to a class variable" ...
+        # but if we don't use `ClassVar`, then the `dataclass_transform` decorator
+        # will add _events: SignalGroup to the __init__ signature, for *all* user models
+        _model_self_._events = Group(_model_self_)  # type: ignore [misc]
 
     def _super_setattr_(self, name: str, value: Any) -> None:
         # pydantic will raise a ValueError if extra fields are not allowed


### PR DESCRIPTION
makes it so that:

```py
class M(EventedModel):
    x: int
```

shows a proper signature in VScode

![Screen Shot 2022-12-20 at 3 19 20 PM](https://user-images.githubusercontent.com/1609449/208758863-3268364d-2df8-41f7-9ac1-788aacf3c68c.png)
