### PR TITLE
feat: add support for msgspec Struct classes to evented decorator

### DIFF
--- a/docs/dataclasses.md
+++ b/docs/dataclasses.md
@@ -60,8 +60,8 @@ print(john)  # prints: Person(name='John', age=30)
 
 ### ... in third-party libraries
 
-Prior to the addition of dataclasses in the standard library, third-party libraries
-were already implementing this pattern:
+There are multiple hird-party libraries that also implement this pattern, or
+something similar:
 
 - the [`attrs` library](https://www.attrs.org/en/stable/) provides [the `@define`
   decorator](https://www.attrs.org/en/stable/overview.html), which is similar to
@@ -70,6 +70,8 @@ were already implementing this pattern:
   [`BaseModel` class](https://pydantic-docs.helpmanual.io/usage/models/),
   a dataclass-like object that can additionally perform type validation and facilitates
   serialization to and from JSON.
+- [msgspec](https://jcristharif.com/msgspec/) provides a
+  [`Struct` class](https://jcristharif.com/msgspec/structs.html)
 
 All of these libraries are still in common use, and each has its own
 strengths and weaknesses (discussed in depth elsewhere).
@@ -77,11 +79,11 @@ strengths and weaknesses (discussed in depth elsewhere).
 ## Evented dataclasses in Psygnal
 
 `psygnal` provides an [`@evented` decorator][psygnal.evented] that can be used
-to decorate any existing dataclass (standard library, `attrs`, or `pydantic`
-model). It adds a new [`SignalGroup`][psygnal.SignalGroup] property to the
-class, with a [`SignalInstance`][psygnal.SignalInstance] for each field in the
-dataclass.  A Signal will be emitted whenever the field value is changed, with
-the new value as the first argument.
+to decorate any existing dataclass (standard library, `attrs`, `msgspec`, or
+`pydantic` model). It adds a new [`SignalGroup`][psygnal.SignalGroup] property
+to the class, with a [`SignalInstance`][psygnal.SignalInstance] for each field
+in the dataclass.  A Signal will be emitted whenever the field value is changed,
+with the new value as the first argument.
 
 !!! example
 
@@ -107,6 +109,18 @@ the new value as the first argument.
         @evented
         @define
         class Person:
+            name: str
+            age: int = 0
+        ```
+
+    === "msgspec"
+
+        ```python
+        from psygnal import evented
+        import msgspec
+
+        @evented
+        class Person(msgspec.Struct):
             name: str
             age: int = 0
         ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,6 @@ test = [
     "pytest-mypy-plugins",
     "pytest>=6.0",
     "wrapt",
-    "msgspec",
     "msgspec ; python_version >= '3.8'",
 ]
 testqt = ["pytest-qt", "qtpy"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,6 +71,7 @@ test = [
     "pytest>=6.0",
     "wrapt",
     "msgspec",
+    "msgspec ; python_version >= '3.8'",
 ]
 testqt = ["pytest-qt", "qtpy"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,6 +90,7 @@ only-include = ["src"]
 sources = ["src"]
 
 [tool.hatch.build.targets.wheel.hooks.mypyc]
+mypy-args = ["--ignore-missing-imports"]
 enable-by-default = false
 require-runtime-dependencies = true
 dependencies = [
@@ -99,7 +100,11 @@ dependencies = [
     "types-attrs",
     "msgspec ; python_version >= '3.8'",
 ]
-include = ["src/psygnal/_signal.py", "src/psygnal/_group.py"]
+include = [
+    "src/psygnal/_signal.py",
+    "src/psygnal/_group.py",
+    "src/psygnal/_evented_decorator.py",
+]
 
 [tool.cibuildwheel]
 # Skip 32-bit builds & PyPy wheels on all platforms
@@ -168,12 +173,12 @@ show_error_codes = true
 pretty = true
 
 [[tool.mypy.overrides]]
-# msgspec is only available on Python 3.8+ ... so we need to ignore it
-module = ["numpy.*", "wrapt", "pydantic.*", "msgspec.*"]
+module = ["numpy.*", "wrapt", "pydantic.*"]
 ignore_errors = true
 
 [[tool.mypy.overrides]]
-module = ["wrapt"]
+# msgspec is only available on Python 3.8+ ... so we need to ignore it
+module = ["wrapt", "msgspec"]
 ignore_missing_imports = true
 
 # https://coverage.readthedocs.io/en/6.4/config.html

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,7 +92,13 @@ sources = ["src"]
 [tool.hatch.build.targets.wheel.hooks.mypyc]
 enable-by-default = false
 require-runtime-dependencies = true
-dependencies = ["hatch-mypyc>=0.13.0", "mypy>=0.991", "pydantic", "types-attrs", "msgspec ; python_version >= '3.8'"]
+dependencies = [
+    "hatch-mypyc>=0.13.0",
+    "mypy>=0.991",
+    "pydantic",
+    "types-attrs",
+    "msgspec ; python_version >= '3.8'",
+]
 include = ["src/psygnal/_signal.py", "src/psygnal/_group.py"]
 
 [tool.cibuildwheel]
@@ -112,11 +118,11 @@ line-length = 88
 target-version = "py37"
 src = ["src", "tests"]
 extend-select = [
-    "E",    # style errors
-    "F",    # flakes
-    "D",    # pydocstyle
-    "I",    # isort
-    "UP",   # pyupgrade
+    "E",  # style errors
+    "F",  # flakes
+    "D",  # pydocstyle
+    "I",  # isort
+    "UP", # pyupgrade
     # "N",  # pep8-naming
     "S",    # bandit
     "C4",   # flake8-comprehensions
@@ -162,11 +168,12 @@ show_error_codes = true
 pretty = true
 
 [[tool.mypy.overrides]]
-module = ["numpy.*", "wrapt", "pydantic.*"]
+# msgspec is only available on Python 3.8+ ... so we need to ignore it
+module = ["numpy.*", "wrapt", "pydantic.*", "msgspec.*"]
 ignore_errors = true
 
 [[tool.mypy.overrides]]
-module = ["wrapt", "msgspec"]  # msgspec ignore is only for py3.7
+module = ["wrapt"]
 ignore_missing_imports = true
 
 # https://coverage.readthedocs.io/en/6.4/config.html
@@ -177,7 +184,7 @@ exclude_lines = [
     "@overload",
     "except ImportError",
     "\\.\\.\\.",
-    "raise NotImplementedError()"
+    "raise NotImplementedError()",
 ]
 [tool.coverage.run]
 source = ["src"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,7 +92,7 @@ sources = ["src"]
 [tool.hatch.build.targets.wheel.hooks.mypyc]
 enable-by-default = false
 require-runtime-dependencies = true
-dependencies = ["hatch-mypyc>=0.13.0", "mypy>=0.991", "pydantic", "types-attrs"]
+dependencies = ["hatch-mypyc>=0.13.0", "mypy>=0.991", "pydantic", "types-attrs", "msgspec ; python_version >= '3.8'"]
 include = ["src/psygnal/_signal.py", "src/psygnal/_group.py"]
 
 [tool.cibuildwheel]
@@ -166,7 +166,7 @@ module = ["numpy.*", "wrapt", "pydantic.*"]
 ignore_errors = true
 
 [[tool.mypy.overrides]]
-module = "wrapt"
+module = ["wrapt", "msgspec"]  # msgspec ignore is only for py3.7
 ignore_missing_imports = true
 
 # https://coverage.readthedocs.io/en/6.4/config.html

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,6 +70,7 @@ test = [
     "pytest-mypy-plugins",
     "pytest>=6.0",
     "wrapt",
+    "msgspec",
 ]
 testqt = ["pytest-qt", "qtpy"]
 

--- a/src/psygnal/_evented_decorator.py
+++ b/src/psygnal/_evented_decorator.py
@@ -313,9 +313,17 @@ class _SignalGroupDescriptor:
         self._name = name
         self._signal_group = group_cls
 
+    @overload
+    def __get__(self, instance: None, owner: type) -> "_SignalGroupDescriptor":
+        ...
+
+    @overload
+    def __get__(self, instance: object, owner: type) -> SignalGroup:
+        ...
+
     def __get__(
         self, instance: object, owner: type
-    ) -> "_SignalGroupDescriptor | SignalGroup":
+    ) -> "SignalGroup | _SignalGroupDescriptor":
         if instance is None:
             return self
 

--- a/src/psygnal/_evented_decorator.py
+++ b/src/psygnal/_evented_decorator.py
@@ -131,7 +131,8 @@ def is_msgspec_struct(cls: Type) -> "TypeGuard[msgspec.Struct]":
 def iter_fields(cls: Type) -> Iterator[Tuple[str, Type]]:
     """Iterate over all mutable fields in the class, including inherited fields.
 
-    This function recognizes dataclasses, attrs classes, and pydantic models.
+    This function recognizes dataclasses, attrs classes, msgspec Structs, and pydantic
+    models.
     """
     if is_dataclass(cls):
         if getattr(cls, _DATACLASS_PARAMS).frozen:  # pragma: no cover
@@ -211,9 +212,11 @@ def evented(
     events_namespace: str = "events",
     equality_operators: Optional[Dict[str, EqOperator]] = None,
 ) -> Union[Callable[[T], T], T]:
-    """A decorator to add events to a [dataclass][dataclasses.dataclass],
-    [attrs](https://www.attrs.org), or [pydantic](https://pydantic-docs.helpmanual.io)
-    model.
+    """A decorator to add events to a dataclass.
+
+    Supports [dataclass][dataclasses.dataclass], [attrs](https://www.attrs.org),
+    [msgspec](https://jcristharif.com/msgspec/) and
+    [pydantic](https://pydantic-docs.helpmanual.io) models.
 
     Note that this decorator will modify `cls` *in place*, as well as return it.
 
@@ -255,7 +258,7 @@ def evented(
         name: str
         age: int = 0
     ```
-    """  # noqa: D
+    """
     _eqop = tuple(equality_operators.items()) if equality_operators else None
 
     def _decorate(cls: T) -> T:
@@ -265,7 +268,7 @@ def evented(
         if not Grp._signals_:
             warnings.warn(
                 f"No mutable fields found in class {cls} no events will be emitted. "
-                "(Is this a dataclass, attrs, or pydantic model?)"
+                "(Is this a dataclass, attrs, msgspec, or pydantic model?)"
             )
             return cls
 

--- a/src/psygnal/_evented_decorator.py
+++ b/src/psygnal/_evented_decorator.py
@@ -307,7 +307,7 @@ class _SignalGroupDescriptor:
     override __init__ (like msgspec.)
     """
 
-    _instance_map: dict[int, SignalGroup] = {}
+    _instance_map: Dict[int, SignalGroup] = {}
 
     def __init__(self, group_cls: Type[SignalGroup], name: str):
         self._name = name

--- a/tests/test_evented_decorator.py
+++ b/tests/test_evented_decorator.py
@@ -8,12 +8,14 @@ import numpy as np
 import pytest
 
 from psygnal import SignalGroup, evented
+from psygnal._evented_decorator import _SignalGroupDescriptor
 
 
 @no_type_check
 def _check_events(cls, events_ns="events"):
     obj = cls(bar=1, baz="2", qux=np.zeros(3))
 
+    assert isinstance(getattr(cls, events_ns), _SignalGroupDescriptor)
     events = getattr(obj, events_ns)
     assert isinstance(events, SignalGroup)
     assert set(events.signals) == {"bar", "baz", "qux"}

--- a/tests/test_evented_decorator.py
+++ b/tests/test_evented_decorator.py
@@ -85,7 +85,7 @@ def test_pydantic_dataclass() -> None:
 
 
 def test_msgspec_struct() -> None:
-    import msgspec
+    msgspec = pytest.importorskip("msgspec")
 
     @evented
     class Foo(msgspec.Struct):

--- a/tests/test_evented_decorator.py
+++ b/tests/test_evented_decorator.py
@@ -84,6 +84,18 @@ def test_pydantic_dataclass() -> None:
     _check_events(Foo)
 
 
+def test_msgspec_struct() -> None:
+    import msgspec
+
+    @evented
+    class Foo(msgspec.Struct):
+        bar: int
+        baz: str
+        qux: np.ndarray
+
+    _check_events(Foo)
+
+
 def test_pydantic_base_model() -> None:
     from pydantic import BaseModel
 
@@ -106,3 +118,18 @@ def test_no_signals_warn():
         @evented
         class Foo:
             bar: int
+
+
+@evented
+@dataclass
+class FooPicklable:
+    bar: int
+
+
+def test_pickle() -> None:
+    """Make sure that evented classes are still picklable."""
+    import pickle
+
+    obj = FooPicklable(1)
+    obj2 = pickle.loads(pickle.dumps(obj))
+    assert obj2.bar == 1


### PR DESCRIPTION
https://github.com/jcrist/msgspec is another fast library that implements a dataclass pattern.

this PR allows

```py
    @evented
    class Foo(msgspec.Struct):
        bar: int
        baz: str
        qux: np.ndarray

```


since `Struct` is a c-extension with restrictions on overriding `__init__` and modifying `__slots__` this PR uses a new approach to create the SignalGroup on instances (using a descriptor on the class rather than a modified init)