### PR TITLE
fix: use weakref when instance is passed to SignalGroup

### DIFF
--- a/src/psygnal/_signal.py
+++ b/src/psygnal/_signal.py
@@ -290,7 +290,12 @@ class SignalInstance:
         check_types_on_connect: bool = False,
     ) -> None:
         self._name = name
-        self._instance: Any = instance
+        try:
+            self._instance: Any = weakref.ref(instance)
+        except TypeError:
+            # fall back to strong reference if instance is not weak-referenceable
+            self._instance = lambda: instance
+
         self._args_queue: list[Any] = []  # filled when paused
 
         if isinstance(signature, (list, tuple)):
@@ -317,7 +322,7 @@ class SignalInstance:
     @property
     def instance(self) -> Any:
         """Object that emits this `SignalInstance`."""
-        return self._instance
+        return self._instance()
 
     @property
     def name(self) -> str:

--- a/src/psygnal/_signal.py
+++ b/src/psygnal/_signal.py
@@ -290,11 +290,14 @@ class SignalInstance:
         check_types_on_connect: bool = False,
     ) -> None:
         self._name = name
-        try:
-            self._instance: Any = weakref.ref(instance)
-        except TypeError:
-            # fall back to strong reference if instance is not weak-referenceable
-            self._instance = lambda: instance
+        if instance is None:
+            self._instance: Callable = lambda: None
+        else:
+            try:
+                self._instance = weakref.ref(instance)
+            except TypeError:
+                # fall back to strong reference if instance is not weak-referenceable
+                self._instance = lambda: instance
 
         self._args_queue: list[Any] = []  # filled when paused
 

--- a/tests/test_group.py
+++ b/tests/test_group.py
@@ -166,3 +166,18 @@ def test_group_disconnect_all_slots():
 
     mock1.assert_not_called()
     mock2.assert_not_called()
+
+
+def test_weakref():
+    """Make sure that the group doesn't keep a strong reference to the instance."""
+    import gc
+
+    class T:
+        ...
+
+    obj = T()
+    group = MyGroup(obj)
+    assert group.instance is obj
+    del obj
+    gc.collect()
+    assert group.instance is None


### PR DESCRIPTION
`SignalGroup` accepts an optional `instance` argument (the object to which it is bound).  This makes sure it's a weakref when possible