### PR TITLE
refactor: use weakmethod instead of _get_method_name

### DIFF
--- a/src/psygnal/_signal.py
+++ b/src/psygnal/_signal.py
@@ -1265,6 +1265,7 @@ class _BoundMethodCaller(SlotCaller):
 
     def __init__(self, slot: MethodType, max_args: int | None = None) -> None:
         self._method_ref = weakref.WeakMethod(slot)
+        self._obj_ref = weakref.ref(slot.__self__)  # needed for equality check
         self._max_args = max_args
 
     def __call__(self, args: tuple[object, ...]) -> bool:
@@ -1279,7 +1280,8 @@ class _BoundMethodCaller(SlotCaller):
     def __eq__(self, other: object) -> bool:
         return (
             isinstance(other, _BoundMethodCaller)
-            and self._method_ref == other._method_ref
+            and self._method_ref() == other._method_ref()
+            and self._obj_ref == other._obj_ref
         )
 
     def slot(self) -> MethodType:
@@ -1294,6 +1296,7 @@ class _PartialMethodCaller(SlotCaller):
 
     def __init__(self, slot: PartialMethod, max_args: int | None = None) -> None:
         self._method_ref = weakref.WeakMethod(slot.func)
+        self._obj_ref = weakref.ref(slot.func.__self__)  # needed for equality check
         self._max_args = max_args
         self._partial_args = slot.args
         self._partial_kwargs = slot.keywords
@@ -1313,7 +1316,8 @@ class _PartialMethodCaller(SlotCaller):
     def __eq__(self, other: object) -> bool:
         return (
             isinstance(other, _PartialMethodCaller)
-            and self._method_ref == other._method_ref
+            and self._method_ref() == other._method_ref()
+            and self._obj_ref == other._obj_ref
         )
 
     def slot(self) -> PartialMethod:

--- a/src/psygnal/_signal.py
+++ b/src/psygnal/_signal.py
@@ -680,6 +680,8 @@ class SignalInstance:
         """Get index of `slot` in `self._slots`.  Return -1 if not connected."""
         with self._lock:
             normed = _slot_caller(slot)
+            # NOTE:
+            # the == method here relies on the __eq__ method of each SlotCaller subclass
             return next((i for i, s in enumerate(self._slots) if s == normed), -1)
 
     def disconnect(self, slot: Callable | None = None, missing_ok: bool = True) -> None:
@@ -1268,7 +1270,7 @@ class _BoundMethodCaller(SlotCaller):
     def __call__(self, args: tuple[object, ...]) -> bool:
         method = self._method_ref()
         if method is None:
-            return True  # object has changed?
+            return True  # object has been deleted
         if self._max_args is not None:
             args = args[: self._max_args]
         method(*args)
@@ -1300,7 +1302,7 @@ class _PartialMethodCaller(SlotCaller):
     def __call__(self, args: tuple[object, ...]) -> bool:
         method = self._method_ref()
         if method is None:
-            return True
+            return True  # object has been deleted
 
         if self._max_args is not None:
             args = args[: self._max_args]

--- a/src/psygnal/_signal.py
+++ b/src/psygnal/_signal.py
@@ -1262,14 +1262,11 @@ class _BoundMethodCaller(SlotCaller):
     """Caller of a (dereferenced) bound method."""
 
     def __init__(self, slot: MethodType, max_args: int | None = None) -> None:
-        self._ref, self._method_name = _get_method_name(slot)
+        self._method_ref = weakref.WeakMethod(slot)
         self._max_args = max_args
 
     def __call__(self, args: tuple[object, ...]) -> bool:
-        obj = self._ref()
-        if obj is None:
-            return True
-        method = getattr(obj, self._method_name, None)
+        method = self._method_ref()
         if method is None:
             return True  # object has changed?
         if self._max_args is not None:
@@ -1280,49 +1277,47 @@ class _BoundMethodCaller(SlotCaller):
     def __eq__(self, other: object) -> bool:
         return (
             isinstance(other, _BoundMethodCaller)
-            and self._ref == other._ref
-            and self._method_name == other._method_name
+            and self._method_ref == other._method_ref
         )
 
     def slot(self) -> MethodType:
-        obj = self._ref()
-        if obj is None:
+        method = self._method_ref()
+        if method is None:
             raise RuntimeError("object has been deleted")  # pragma: no cover
-        return cast(MethodType, getattr(obj, self._method_name))
+        return method
 
 
 class _PartialMethodCaller(SlotCaller):
     """Caller of a partial to a (dereferenced) bound method."""
 
     def __init__(self, slot: PartialMethod, max_args: int | None = None) -> None:
-        self._ref, self._method_name = _get_method_name(slot.func)
+        self._method_ref = weakref.WeakMethod(slot.func)
         self._max_args = max_args
         self._partial_args = slot.args
         self._partial_kwargs = slot.keywords
         self._slot_id = id(slot)
 
     def __call__(self, args: tuple[object, ...]) -> bool:
-        obj = self._ref()
-        if obj is None:
+        method = self._method_ref()
+        if method is None:
             return True
+
         if self._max_args is not None:
             args = args[: self._max_args]
-        method = getattr(obj, self._method_name)
+
         method(*self._partial_args, *args, **self._partial_kwargs)
         return False
 
     def __eq__(self, other: object) -> bool:
         return (
             isinstance(other, _PartialMethodCaller)
-            and self._ref == other._ref
-            and self._method_name == other._method_name
+            and self._method_ref == other._method_ref
         )
 
     def slot(self) -> PartialMethod:
-        obj = self._ref()
-        if obj is None:
+        method = self._method_ref()
+        if method is None:
             raise RuntimeError("object has been deleted")  # pragma: no cover
-        method = getattr(obj, self._method_name)
         _partial = partial(method, *self._partial_args, **self._partial_kwargs)
         return cast(PartialMethod, _partial)
 
@@ -1449,30 +1444,8 @@ _PARTIAL_CACHE: dict[int, _PartialMethodCaller] = {}
 def _prune_partial_cache() -> None:
     """Remove any partial methods whose object has been garbage collected."""
     for key, caller in list(_PARTIAL_CACHE.items()):
-        if caller._ref() is None:
+        if caller._method_ref() is None:
             del _PARTIAL_CACHE[key]
-
-
-def _get_method_name(slot: MethodType) -> tuple[weakref.ref, str]:
-    obj = slot.__self__
-    # some decorators will alter method.__name__, so that obj.method
-    # will not be equal to getattr(obj, obj.method.__name__).
-    # We check for that case here and find the proper name in the function's closures
-    if getattr(obj, slot.__name__, None) != slot:
-        for c in slot.__closure__ or ():
-            cname = getattr(c.cell_contents, "__name__", None)
-            if cname and getattr(obj, cname, None) == slot:
-                return weakref.ref(obj), cname
-        # slower, but catches cases like assigned functions
-        # that won't have function in closure
-        for name in reversed(dir(obj)):  # most dunder methods come first
-            if getattr(obj, name) == slot:
-                return weakref.ref(obj), name
-        # we don't know what to do here.
-        raise RuntimeError(  # pragma: no cover
-            f"Could not find method on {obj} corresponding to decorated function {slot}"
-        )
-    return weakref.ref(obj), slot.__name__
 
 
 def _guess_qtsignal_signature(obj: Any) -> str | None:

--- a/src/psygnal/_signal.py
+++ b/src/psygnal/_signal.py
@@ -1267,7 +1267,7 @@ class _BoundMethodCaller(SlotCaller):
         try:
             obj = slot.__self__
             func = slot.__func__
-        except AttributeError:
+        except AttributeError:  # pragma: no cover
             raise TypeError(
                 f"argument should be a bound method, not {type(slot)}"
             ) from None

--- a/tests/test_psygnal.py
+++ b/tests/test_psygnal.py
@@ -900,7 +900,7 @@ def test_multiple_bound_methods():
     e.one_int.connect(p2)
     e.one_int.connect(p3)
 
-    assert [s._method_ref() for s in e.one_int._slots] == [
+    assert [s._method() for s in e.one_int._slots] == [
         obj1.f_int,
         obj2.f_int,
         obj3.f_int,
@@ -913,7 +913,7 @@ def test_multiple_bound_methods():
     ]
 
     e.one_int.disconnect(obj2.f_any)
-    assert [s._method_ref() for s in e.one_int._slots] == [
+    assert [s._method() for s in e.one_int._slots] == [
         obj1.f_int,
         obj2.f_int,
         obj3.f_int,
@@ -928,14 +928,14 @@ def test_multiple_bound_methods():
     gc.collect()
     e.one_int.disconnect(p3)
     e.one_int.emit(1)
-    assert [s._method_ref() for s in e.one_int._slots] == (
+    assert [s._method() for s in e.one_int._slots] == (
         [obj1.f_int, obj3.f_int, obj3.f_any, obj1.f_any, obj1.f_int_int]
     )
 
     del p1, obj1
     gc.collect()
     e.one_int.emit(1)
-    assert [s._method_ref() for s in e.one_int._slots] == [
+    assert [s._method() for s in e.one_int._slots] == [
         obj3.f_int,
         obj3.f_any,
     ]

--- a/tests/test_psygnal.py
+++ b/tests/test_psygnal.py
@@ -14,7 +14,6 @@ from psygnal._signal import (
     SlotCaller,
     _BoundMethodCaller,
     _FunctionCaller,
-    _get_method_name,
     _PartialMethodCaller,
     _SetattrCaller,
     _SetitemCaller,
@@ -703,13 +702,6 @@ def test_debug_import(monkeypatch):
     import psygnal
 
     assert not psygnal._compiled
-
-
-def test_get_method_name():
-    obj = MyObj()
-    assert _get_method_name(obj.f_int_decorated_stupid)[1] == "f_int_decorated_stupid"
-    assert _get_method_name(obj.f_int_decorated_good)[1] == "f_int_decorated_good"
-    assert _get_method_name(obj.f_any_assigned)[1] == "f_any_assigned"
 
 
 def test_property_connect():

--- a/tests/test_psygnal.py
+++ b/tests/test_psygnal.py
@@ -954,6 +954,9 @@ def test_slot_caller_equality():
 
     t1 = T()
     t2 = T()
+    t1_ref = ref(t1) 
+    t2_ref = ref(t2)
+    
 
     bmt1_a = _BoundMethodCaller(t1.x)
     bmt1_b = _BoundMethodCaller(t1.x)

--- a/tests/test_psygnal.py
+++ b/tests/test_psygnal.py
@@ -954,9 +954,8 @@ def test_slot_caller_equality():
 
     t1 = T()
     t2 = T()
-    t1_ref = ref(t1) 
+    t1_ref = ref(t1)
     t2_ref = ref(t2)
-    
 
     bmt1_a = _BoundMethodCaller(t1.x)
     bmt1_b = _BoundMethodCaller(t1.x)

--- a/tests/test_psygnal.py
+++ b/tests/test_psygnal.py
@@ -969,6 +969,7 @@ def test_slot_caller_equality():
     _assert_equality()
     del t1
     gc.collect()
+    assert t1_ref() is None
     _assert_equality()
     del t2
     gc.collect()

--- a/tests/test_psygnal.py
+++ b/tests/test_psygnal.py
@@ -6,6 +6,7 @@ from functools import partial, wraps
 from inspect import Signature
 from typing import Optional, Type
 from unittest.mock import MagicMock, Mock, call
+from weakref import ref
 
 import pytest
 

--- a/tests/test_psygnal.py
+++ b/tests/test_psygnal.py
@@ -943,3 +943,33 @@ def test_multiple_bound_methods():
     gc.collect()
     e.one_int.emit(1)
     assert not e.one_int._slots
+
+
+def test_slot_caller_equality():
+    """Slot callers should be equal only if they represent the same bound-method."""
+
+    class T:
+        def x(self):
+            ...
+
+    t1 = T()
+    t2 = T()
+
+    bmt1_a = _BoundMethodCaller(t1.x)
+    bmt1_b = _BoundMethodCaller(t1.x)
+    bmt2_a = _BoundMethodCaller(t2.x)
+    bmt2_b = _BoundMethodCaller(t2.x)
+
+    def _assert_equality():
+        assert bmt1_a == bmt1_b
+        assert bmt2_a == bmt2_b
+        assert bmt1_a != bmt2_a
+        assert bmt1_b != bmt2_b
+
+    _assert_equality()
+    del t1
+    gc.collect()
+    _assert_equality()
+    del t2
+    gc.collect()
+    _assert_equality()

--- a/tests/test_psygnal.py
+++ b/tests/test_psygnal.py
@@ -972,4 +972,5 @@ def test_slot_caller_equality():
     _assert_equality()
     del t2
     gc.collect()
+    assert t2_ref() is None
     _assert_equality()


### PR DESCRIPTION
This replaces some complicated internal logic for storing a weak reference to a bound method with [`weakref.WeakMethod`](https://docs.python.org/3/library/weakref.html#weakref.WeakMethod) ... it _seems_ like this is what should have been used all along?  @Czaki  ... would appreciate your thoughts if you have a moment to check