### PR TITLE
test: no cover compile funcs

### DIFF
--- a/src/psygnal/utils.py
+++ b/src/psygnal/utils.py
@@ -85,7 +85,7 @@ def decompile() -> None:
 
     This function requires write permissions to the psygnal source directory.
     """
-    for suffix in _COMPILED_EXTS:
+    for suffix in _COMPILED_EXTS:  # pragma: no cover
         for path in Path(__file__).parent.rglob(f"**/*{suffix}"):
             path.rename(path.with_suffix(f"{suffix}{_BAK}"))
 
@@ -95,6 +95,6 @@ def recompile() -> None:
 
     This function requires write permissions to the psygnal source directory.
     """
-    for suffix in _COMPILED_EXTS:
+    for suffix in _COMPILED_EXTS:  # pragma: no cover
         for path in Path(__file__).parent.rglob(f"**/*{suffix}{_BAK}"):
             path.rename(path.with_suffix(suffix))

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -37,10 +37,7 @@ def test_event_debugger(capsys):
     assert captured.out == "sig.emit(1, 2)\nsig.emit(3, 4)\n"
 
 
-OLD_WIN = bool((sys.version_info < (3, 8)) and os.name == "nt")
-
-
-@pytest.mark.skipif(OLD_WIN, reason="can't rewrite open files on Windows")
+@pytest.mark.skipif(os.name == "nt", reason="rewrite open files on Windows is buggy")
 def test_decompile_recompile(monkeypatch):
     import psygnal
 


### PR DESCRIPTION
skip coverage on the decompile/recompile utility functions (they're tested, but difficult for coverage)