### PR TITLE
fix: fix strict signal group checking when signatures aren't hashable

### DIFF
--- a/src/psygnal/_group.py
+++ b/src/psygnal/_group.py
@@ -252,9 +252,9 @@ class SignalGroup(SignalInstance):
 
 def _is_uniform(signals: Iterable[Signal]) -> bool:
     """Return True if all signals have the same signature."""
-    seen: set[str] = set()
+    seen: set[tuple[str, ...]] = set()
     for s in signals:
-        v = str(s.signature)
+        v = tuple(str(p.annotation) for p in s.signature.parameters.values())
         if seen and v not in seen:  # allow zero or one
             return False
         seen.add(v)

--- a/src/psygnal/_signal.py
+++ b/src/psygnal/_signal.py
@@ -1332,13 +1332,16 @@ def _guess_qtsignal_signature(obj: Any) -> str | None:
     qualname = getattr(obj, "__qualname__", "")
     if qualname == "pyqtBoundSignal.emit":
         return cast("str", obj.__self__.signal)
+
+    # note: this IS all actually covered in tests... but only in the Qt tests,
+    # so it (annoyingly) briefly looks like it fails coverage.
     if qualname == "SignalInstance.emit" and type_.__name__.startswith("builtin"):
         # we likely have the emit method of a SignalInstance
         # call it with ridiculous params to get the err
-        return _ridiculously_call_emit(obj.__self__.emit)
+        return _ridiculously_call_emit(obj.__self__.emit)  # pragma: no cover
     if "SignalInstance" in type_.__name__ and "QtCore" in getattr(
         type_, "__module__", ""
-    ):
+    ):  # pragma: no cover
         return _ridiculously_call_emit(obj.emit)
     return None
 
@@ -1346,7 +1349,9 @@ def _guess_qtsignal_signature(obj: Any) -> str | None:
 _CRAZY_ARGS = (1,) * 255
 
 
-def _ridiculously_call_emit(emitter: Any) -> str | None:
+# note: this IS all actually covered in tests... but only in the Qt tests,
+# so it (annoyingly) briefly looks like it fails coverage.
+def _ridiculously_call_emit(emitter: Any) -> str | None:  # pragma: no cover
     """Call SignalInstance emit() to get the signature from err message."""
     try:
         emitter(*_CRAZY_ARGS)

--- a/tests/test_group.py
+++ b/tests/test_group.py
@@ -1,7 +1,7 @@
-from typing import Annotated
 from unittest.mock import Mock, call
 
 import pytest
+from typing_extensions import Annotated
 
 from psygnal import EmissionInfo, Signal, SignalGroup
 

--- a/tests/test_group.py
+++ b/tests/test_group.py
@@ -1,3 +1,4 @@
+from typing import Annotated
 from unittest.mock import Mock, call
 
 import pytest
@@ -40,6 +41,22 @@ def test_uniform_group():
             sig2 = Signal(int)
 
     assert str(e.value).startswith("All Signals in a strict SignalGroup must")
+
+
+def test_nonhashable_args():
+    """Test that non-hashable annotations are allowed in a SignalGroup"""
+
+    class MyGroup(SignalGroup):
+        sig1 = Signal(Annotated[int, {"a": 1}])  # type: ignore
+        sig2 = Signal(Annotated[float, {"b": 1}])  # type: ignore
+
+    assert not MyGroup.is_uniform()
+
+    with pytest.raises(TypeError):
+
+        class MyGroup2(SignalGroup, strict=True):
+            sig1 = Signal(Annotated[int, {"a": 1}])  # type: ignore
+            sig2 = Signal(Annotated[float, {"b": 1}])  # type: ignore
 
 
 @pytest.mark.parametrize("direct", [True, False])


### PR DESCRIPTION
closes #191 