### PR TITLE
build: add pyinstaller hook to simplify frozing apps using pyinstaller 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -168,7 +168,7 @@ testpaths = ["tests"]
 filterwarnings = [
     "error",
     "ignore:The distutils package is deprecated:DeprecationWarning:",
-    "ignore:BackendFinder.find_spec() not found; falling back to find_module()", # pyinstaller import
+    "ignore:BackendFinder.find_spec()", # pyinstaller import
 ]
 
 # https://mypy.readthedocs.io/en/stable/config_file.html

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,7 @@ test = [
     "dask",
     "numpy",
     "pydantic",
-    "pyinstalle>=4.0",
+    "pyinstaller>=4.0",
     "pytest>=6.0",
     "pytest-codspeed",
     "pytest-cov",
@@ -81,7 +81,7 @@ repository = "https://github.com/pyapp-kit/psygnal"
 documentation = "https://psygnal.readthedocs.io"
 
 [project.entry-points.pyinstaller40]
-hook-dirs = "psygnal._pyinstaller_hook:get_hook_dirs"
+hook-dirs = "psygnal._pyinstaller_util._pyinstaller_hook:get_hook_dirs"
 
 [tool.hatch.version]
 source = "vcs"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -168,7 +168,7 @@ testpaths = ["tests"]
 filterwarnings = [
     "error",
     "ignore:The distutils package is deprecated:DeprecationWarning:",
-    "ignore:BackendFinder.find_spec()", # pyinstaller import
+    "ignore:ImportWarning: BackendFinder.find_spec()", # pyinstaller import
 ]
 
 # https://mypy.readthedocs.io/en/stable/config_file.html

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -168,7 +168,7 @@ testpaths = ["tests"]
 filterwarnings = [
     "error",
     "ignore:The distutils package is deprecated:DeprecationWarning:",
-    "ignore:ImportWarning: BackendFinder.find_spec()", # pyinstaller import
+    "ignore:.*BackendFinder.find_spec()", # pyinstaller import
 ]
 
 # https://mypy.readthedocs.io/en/stable/config_file.html

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,7 @@ test = [
     "dask",
     "numpy",
     "pydantic",
+    "pyinstalle>=4.0",
     "pytest>=6.0",
     "pytest-codspeed",
     "pytest-cov",
@@ -78,6 +79,9 @@ testqt = ["pytest-qt", "qtpy"]
 homepage = "https://github.com/pyapp-kit/psygnal"
 repository = "https://github.com/pyapp-kit/psygnal"
 documentation = "https://psygnal.readthedocs.io"
+
+[project.entry-points.pyinstaller40]
+hook-dirs = "psygnal._pyinstaller_hook:get_hook_dirs"
 
 [tool.hatch.version]
 source = "vcs"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -168,7 +168,7 @@ testpaths = ["tests"]
 filterwarnings = [
     "error",
     "ignore:The distutils package is deprecated:DeprecationWarning:",
-    "BackendFinder.find_spec() not found; falling back to find_module()", # pyinstaller import
+    "ignore:BackendFinder.find_spec() not found; falling back to find_module()", # pyinstaller import
 ]
 
 # https://mypy.readthedocs.io/en/stable/config_file.html

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -168,6 +168,7 @@ testpaths = ["tests"]
 filterwarnings = [
     "error",
     "ignore:The distutils package is deprecated:DeprecationWarning:",
+    "BackendFinder.find_spec() not found; falling back to find_module()", # pyinstaller import
 ]
 
 # https://mypy.readthedocs.io/en/stable/config_file.html

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -201,6 +201,7 @@ exclude_lines = [
 ]
 [tool.coverage.run]
 source = ["src"]
+omit = ["src/psygnal/_pyinstaller_util/hook-psygnal.py"]
 
 # https://github.com/mgedmin/check-manifest#configuration
 [tool.check-manifest]

--- a/src/psygnal/_pyinstaller_util/_pyinstaller_hook.py
+++ b/src/psygnal/_pyinstaller_util/_pyinstaller_hook.py
@@ -1,0 +1,8 @@
+from pathlib import Path
+from typing import List
+
+CURRENT_DIR = Path(__file__).parent
+
+
+def get_hook_dirs() -> List[str]:
+    return [str(CURRENT_DIR)]

--- a/src/psygnal/_pyinstaller_util/hook-psygnal.py
+++ b/src/psygnal/_pyinstaller_util/hook-psygnal.py
@@ -11,7 +11,12 @@ except ImportError:
     )
     from importlib_metadata import files as package_files  # type: ignore[no-redef]
 
-CURRENT_DIR = Path(__file__).parent
+try:
+    import psygnal
+
+    PSYGNAL_DIR = Path(psygnal.__file__).parent
+except ImportError:
+    PSYGNAL_DIR = Path(__file__).parent.parent
 
 
 def binary_files(file_list: Iterable[Union[PackagePath, Path]]) -> List[Path]:
@@ -34,11 +39,11 @@ def create_hiddenimports() -> List[str]:
     if not modules:
         # This is a workaround for a bug in importlib.metadata in editable mode
 
-        src_path = CURRENT_DIR.parent.parent
+        src_path = PSYGNAL_DIR.parent
 
         modules = [
             x.relative_to(src_path)
-            for x in binary_files(CURRENT_DIR.parent.iterdir())
+            for x in binary_files(PSYGNAL_DIR.iterdir())
             + binary_files(src_path.iterdir())
         ]
 

--- a/src/psygnal/_pyinstaller_util/hook-psygnal.py
+++ b/src/psygnal/_pyinstaller_util/hook-psygnal.py
@@ -1,0 +1,18 @@
+import contextlib
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import files as package_files
+
+hiddenimports = ["mypy_extensions"]
+
+with contextlib.suppress(PackageNotFoundError):
+    files_list = package_files("psygnal")
+
+    if files_list is not None:
+        for package_path in files_list:
+            if package_path.suffix in {".so", ".pyd"}:
+                hiddenimports.append(
+                    package_path.name.split(".")[0].replace("/", ".").replace("\\", ".")
+                )
+
+
+hiddenimports.append("mypy_extensions")

--- a/src/psygnal/_pyinstaller_util/hook-psygnal.py
+++ b/src/psygnal/_pyinstaller_util/hook-psygnal.py
@@ -36,7 +36,7 @@ def create_hiddenimports() -> List[str]:
 
     modules = binary_files(files_list)
 
-    if not modules:
+    if len(modules) < 2:
         # This is a workaround for a bug in importlib.metadata in editable mode
 
         src_path = PSYGNAL_DIR.parent

--- a/src/psygnal/_pyinstaller_util/hook-psygnal.py
+++ b/src/psygnal/_pyinstaller_util/hook-psygnal.py
@@ -1,18 +1,43 @@
-import contextlib
-from importlib.metadata import PackageNotFoundError
+from importlib.metadata import PackageNotFoundError, PackagePath
 from importlib.metadata import files as package_files
+from pathlib import Path
+from typing import Iterable, List, Union
 
-hiddenimports = ["mypy_extensions"]
-
-with contextlib.suppress(PackageNotFoundError):
-    files_list = package_files("psygnal")
-
-    if files_list is not None:
-        for package_path in files_list:
-            if package_path.suffix in {".so", ".pyd"}:
-                hiddenimports.append(
-                    package_path.name.split(".")[0].replace("/", ".").replace("\\", ".")
-                )
+CURRENT_DIR = Path(__file__).parent
 
 
-hiddenimports.append("mypy_extensions")
+def binary_files(file_list: Iterable[Union[PackagePath, Path]]) -> List[Path]:
+    return [Path(file) for file in file_list if file.suffix in {".so", ".pyd"}]
+
+
+def create_hiddenimports() -> list[str]:
+    res = ["mypy_extensions", "__future__"]
+
+    try:
+        files_list = package_files("psygnal")
+    except PackageNotFoundError:
+        return res
+
+    if files_list is None:
+        return res
+
+    modules = binary_files(files_list)
+
+    if not modules:
+        # This is a workaround for a bug in importlib.metadata in editable mode
+
+        src_path = CURRENT_DIR.parent.parent
+
+        modules = [
+            x.relative_to(src_path)
+            for x in binary_files(CURRENT_DIR.parent.iterdir())
+            + binary_files(src_path.iterdir())
+        ]
+
+    for module in modules:
+        res.append(str(module).split(".")[0].replace("/", ".").replace("\\", "."))
+
+    return res
+
+
+hiddenimports = create_hiddenimports()

--- a/src/psygnal/_pyinstaller_util/hook-psygnal.py
+++ b/src/psygnal/_pyinstaller_util/hook-psygnal.py
@@ -1,7 +1,15 @@
-from importlib.metadata import PackageNotFoundError, PackagePath
-from importlib.metadata import files as package_files
 from pathlib import Path
 from typing import Iterable, List, Union
+
+try:
+    from importlib.metadata import PackageNotFoundError, PackagePath
+    from importlib.metadata import files as package_files
+except ImportError:
+    from importlib_metadata import (  # type: ignore[no-redef]
+        PackageNotFoundError,
+        PackagePath,
+    )
+    from importlib_metadata import files as package_files  # type: ignore[no-redef]
 
 CURRENT_DIR = Path(__file__).parent
 
@@ -10,7 +18,7 @@ def binary_files(file_list: Iterable[Union[PackagePath, Path]]) -> List[Path]:
     return [Path(file) for file in file_list if file.suffix in {".so", ".pyd"}]
 
 
-def create_hiddenimports() -> list[str]:
+def create_hiddenimports() -> List[str]:
     res = ["mypy_extensions", "__future__"]
 
     try:

--- a/src/psygnal/_pyinstaller_util/test_pyinstaller_hook.py
+++ b/src/psygnal/_pyinstaller_util/test_pyinstaller_hook.py
@@ -1,0 +1,25 @@
+import subprocess
+from pathlib import Path
+
+from PyInstaller import __main__ as pyi_main
+
+
+def test_pyintstaller_hiddenimports(tmp_path: Path) -> None:
+    build_path = tmp_path / "build"
+    dist_path = tmp_path / "dist"
+    app_name = "psygnal_test"
+    app = tmp_path / (app_name + ".py")
+    app.write_text("\n".join(["import psygnal", "print(psygnal.__version__)"]))
+
+    args = [
+        # Place all generated files in ``tmp_path``.
+        "--workpath",
+        str(build_path),
+        "--distpath",
+        str(dist_path),
+        "--specpath",
+        str(tmp_path),
+        str(app),
+    ]
+    pyi_main.run(args)
+    subprocess.run([str(dist_path / app_name / app_name)], check=True)

--- a/tests/test_pyinstaller_hook.py
+++ b/tests/test_pyinstaller_hook.py
@@ -1,8 +1,24 @@
+import importlib.util
+import os
 import subprocess
 from pathlib import Path
 
 import pytest
 from PyInstaller import __main__ as pyi_main
+
+import psygnal
+
+
+def test_hook_content():
+    spec = importlib.util.spec_from_file_location(
+        "hook",
+        os.path.join(
+            os.path.dirname(psygnal.__file__), "_pyinstaller_util", "hook-psygnal.py"
+        ),
+    )
+    hook = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(hook)
+    assert "psygnal._dataclass_utils" in hook.hiddenimports
 
 
 def test_pyintstaller_hiddenimports(tmp_path: Path) -> None:

--- a/tests/test_pyinstaller_hook.py
+++ b/tests/test_pyinstaller_hook.py
@@ -4,7 +4,6 @@ import subprocess
 from pathlib import Path
 
 import pytest
-from PyInstaller import __main__ as pyi_main
 
 import psygnal
 
@@ -24,6 +23,9 @@ def test_hook_content():
 
 
 def test_pyintstaller_hiddenimports(tmp_path: Path) -> None:
+    with pytest.warns():
+        from PyInstaller import __main__ as pyi_main
+
     build_path = tmp_path / "build"
     dist_path = tmp_path / "dist"
     app_name = "psygnal_test"

--- a/tests/test_pyinstaller_hook.py
+++ b/tests/test_pyinstaller_hook.py
@@ -1,6 +1,7 @@
 import subprocess
 from pathlib import Path
 
+import pytest
 from PyInstaller import __main__ as pyi_main
 
 
@@ -21,5 +22,6 @@ def test_pyintstaller_hiddenimports(tmp_path: Path) -> None:
         str(tmp_path),
         str(app),
     ]
-    pyi_main.run(args)
+    with pytest.warns():
+        pyi_main.run(args)
     subprocess.run([str(dist_path / app_name / app_name)], check=True)

--- a/tests/test_pyinstaller_hook.py
+++ b/tests/test_pyinstaller_hook.py
@@ -23,5 +23,6 @@ def test_pyintstaller_hiddenimports(tmp_path: Path) -> None:
         str(app),
     ]
     with pytest.warns():
+        # silence warnings about deprecations
         pyi_main.run(args)
     subprocess.run([str(dist_path / app_name / app_name)], check=True)

--- a/tests/test_pyinstaller_hook.py
+++ b/tests/test_pyinstaller_hook.py
@@ -20,9 +20,7 @@ def test_hook_content():
     hook = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(hook)
 
-    assert "psygnal._dataclass_utils" in hook.hiddenimports, list(
-        hook.PSYGNAL_DIR.iterdir()
-    )
+    assert "psygnal._dataclass_utils" in hook.hiddenimports
 
 
 def test_pyintstaller_hiddenimports(tmp_path: Path) -> None:

--- a/tests/test_pyinstaller_hook.py
+++ b/tests/test_pyinstaller_hook.py
@@ -4,12 +4,9 @@ import subprocess
 import warnings
 from pathlib import Path
 
-import pytest
-
 import psygnal
 
 
-@pytest.mark.skipif(not psygnal._compiled, reason="Compiled psygnal not found")
 def test_hook_content():
     spec = importlib.util.spec_from_file_location(
         "hook",
@@ -19,6 +16,11 @@ def test_hook_content():
     )
     hook = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(hook)
+
+    assert "mypy_extensions" in hook.hiddenimports
+
+    if not psygnal._compiled:
+        return
 
     assert "psygnal._dataclass_utils" in hook.hiddenimports
 

--- a/tests/test_pyinstaller_hook.py
+++ b/tests/test_pyinstaller_hook.py
@@ -19,7 +19,10 @@ def test_hook_content():
     )
     hook = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(hook)
-    assert "psygnal._dataclass_utils" in hook.hiddenimports
+
+    assert "psygnal._dataclass_utils" in hook.hiddenimports, list(
+        hook.PSYGNAL_DIR.iterdir()
+    )
 
 
 def test_pyintstaller_hiddenimports(tmp_path: Path) -> None:

--- a/tests/test_pyinstaller_hook.py
+++ b/tests/test_pyinstaller_hook.py
@@ -9,6 +9,7 @@ from PyInstaller import __main__ as pyi_main
 import psygnal
 
 
+@pytest.mark.skipif(not psygnal._compiled, reason="Compiled psygnal not found")
 def test_hook_content():
     spec = importlib.util.spec_from_file_location(
         "hook",

--- a/tests/test_pyinstaller_hook.py
+++ b/tests/test_pyinstaller_hook.py
@@ -1,6 +1,7 @@
 import importlib.util
 import os
 import subprocess
+import warnings
 from pathlib import Path
 
 import pytest
@@ -23,7 +24,9 @@ def test_hook_content():
 
 
 def test_pyintstaller_hiddenimports(tmp_path: Path) -> None:
-    with pytest.warns():
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+
         from PyInstaller import __main__ as pyi_main
 
     build_path = tmp_path / "build"
@@ -42,7 +45,9 @@ def test_pyintstaller_hiddenimports(tmp_path: Path) -> None:
         str(tmp_path),
         str(app),
     ]
-    with pytest.warns():
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
         # silence warnings about deprecations
         pyi_main.run(args)
     subprocess.run([str(dist_path / app_name / app_name)], check=True)


### PR DESCRIPTION
see https://github.com/pyapp-kit/psygnal/issues/162#issuecomment-1446344343

I have created code to automatically add every `.so`, `pyd` file to hidden imports. 

It is a little complicated but reduces maintenance. Maybe I should just hardcode the list? 
