### PR TITLE
feat: add `queue` flag to `SignalInstance.emit` method

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,7 @@ docs = [
     "mkdocs==1.4.2",
     "mkdocstrings-python==0.8.3",
     "mkdocstrings==0.20.0",
-    "mkdocs-spellcheck[all]"
+    "mkdocs-spellcheck[all]",
 ]
 proxy = ["wrapt"]
 pydantic = ["pydantic"]
@@ -104,14 +104,12 @@ dependencies = [
     "types-attrs",
     "msgspec ; python_version >= '3.8'",
 ]
-include = [
-    "src/psygnal/_dataclass_utils.py",
-    "src/psygnal/_evented_decorator.py",
-    "src/psygnal/_group_descriptor.py",
-    "src/psygnal/_group.py",
-    "src/psygnal/_signal.py",
-    "src/psygnal/_throttler.py",
-    "src/psygnal/_weak_callback.py",
+exclude = [
+    "src/psygnal/__init__.py",
+    "src/psygnal/_evented_model.py",
+    "src/psygnal/utils.py",
+    "src/psygnal/containers",
+    "src/psygnal/_pyinstaller_util",
 ]
 
 [tool.cibuildwheel]
@@ -168,7 +166,7 @@ testpaths = ["tests"]
 filterwarnings = [
     "error",
     "ignore:The distutils package is deprecated:DeprecationWarning:",
-    "ignore:.*BackendFinder.find_spec()", # pyinstaller import
+    "ignore:.*BackendFinder.find_spec()",                             # pyinstaller import
 ]
 
 # https://mypy.readthedocs.io/en/stable/config_file.html

--- a/src/psygnal/__init__.py
+++ b/src/psygnal/__init__.py
@@ -34,6 +34,7 @@ __all__ = [
     "debounced",
     "EmissionInfo",
     "EmitLoopError",
+    "emit_queued",
     "evented",
     "EventedModel",
     "get_evented_namespace",
@@ -63,6 +64,7 @@ from ._group_descriptor import (
     get_evented_namespace,
     is_evented,
 )
+from ._queue import emit_queued
 from ._signal import EmitLoopError, Signal, SignalInstance, _compiled
 from ._throttler import debounced, throttled
 

--- a/src/psygnal/_pyinstaller_util/hook-psygnal.py
+++ b/src/psygnal/_pyinstaller_util/hook-psygnal.py
@@ -24,7 +24,7 @@ def binary_files(file_list: Iterable[Union[PackagePath, Path]]) -> List[Path]:
 
 
 def create_hiddenimports() -> List[str]:
-    res = ["mypy_extensions", "__future__"]
+    res = ["queue", "mypy_extensions", "__future__"]
 
     try:
         files_list = package_files("psygnal")
@@ -47,9 +47,10 @@ def create_hiddenimports() -> List[str]:
             + binary_files(src_path.iterdir())
         ]
 
-    for module in modules:
-        res.append(str(module).split(".")[0].replace("/", ".").replace("\\", "."))
-
+    res.extend(
+        str(module).split(".")[0].replace("/", ".").replace("\\", ".")
+        for module in modules
+    )
     return res
 
 

--- a/src/psygnal/_queue.py
+++ b/src/psygnal/_queue.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+from queue import Queue
+from typing import TYPE_CHECKING, TypeVar
+
+from typing_extensions import Protocol
+
+if TYPE_CHECKING:
+    from psygnal import SignalInstance
+
+T = TypeVar("T")
+
+
+class QueueLike(Protocol[T]):
+    """A protocol for a queue-like object.
+
+    This is used to type the `queue` argument to `emit_queued()`.
+    """
+
+    def empty(self) -> bool:
+        ...
+
+    def get(self, block: bool = True, timeout: float | None = None) -> T:
+        ...
+
+    def put(self, item: T, block: bool = True, timeout: float | None = None) -> None:
+        ...
+
+
+SigArgTuple = tuple["SignalInstance", tuple]
+SignalQueue = Queue[SigArgTuple]
+_GLOBAL_QUEUE: Queue[SigArgTuple] = Queue()
+
+
+def emit_queued(queue: SignalQueue = _GLOBAL_QUEUE) -> None:
+    """Emit all signals that have been queued with `self.queue_emit()`.
+
+    This method is thread safe.
+
+    This is designed to be called from the main thread in some sort of event
+    loop, and will emit all signals that have been queued with `self.queue_emit()`
+    (which may have been queued from a different thread).
+
+    How you call this method is up to you.  For example, in Qt, you could call it
+    from a QTimer, or from a QEventLoop:
+
+    Examples
+    --------
+    ```python
+    from qtpy.QtCore import QTimer, Qt
+    from psygnal import Signal, emit_queued
+    import threading
+
+    class Emitter:
+        sig = Signal(int)
+
+    obj = Emitter()
+
+    @obj.sig.connect
+    def on_emit(value: int):
+        print(f"got value {value} from thread {threading.current_thread().name!r}")
+
+    # this timer lives in the main thread
+    timer = QTimer()
+
+    # whenever the timer times out, it will call `emit_queued`
+    timer.timeout.connect(emit_queued)
+    timer.start(0)  # start the timer
+
+    def _some_thread_that_emits() -> None:
+        # inside the thread call `emit()` with `queue=True`
+        obj.sig.emit(1, queue=True)
+
+    threading.Thread(target=_some_thread_that_emits).start()
+    ```
+    """
+    while not queue.empty():
+        sig, args = queue.get()
+        sig._run_emit_loop(args)

--- a/src/psygnal/_queue.py
+++ b/src/psygnal/_queue.py
@@ -28,7 +28,7 @@ class QueueLike(Protocol[T]):
 
 
 SigArgTuple = Tuple["SignalInstance", tuple]
-SignalQueue = Queue[SigArgTuple]
+SignalQueue = QueueLike[SigArgTuple]
 _GLOBAL_QUEUE: Queue[SigArgTuple] = Queue()
 
 

--- a/src/psygnal/_queue.py
+++ b/src/psygnal/_queue.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from queue import Queue
-from typing import TYPE_CHECKING, TypeVar
+from typing import TYPE_CHECKING, Tuple, TypeVar
 
 from typing_extensions import Protocol
 
@@ -27,7 +27,7 @@ class QueueLike(Protocol[T]):
         ...
 
 
-SigArgTuple = tuple["SignalInstance", tuple]
+SigArgTuple = Tuple[SignalInstance, tuple]
 SignalQueue = Queue[SigArgTuple]
 _GLOBAL_QUEUE: Queue[SigArgTuple] = Queue()
 

--- a/src/psygnal/_queue.py
+++ b/src/psygnal/_queue.py
@@ -27,7 +27,7 @@ class QueueLike(Protocol[T]):
         ...
 
 
-SigArgTuple = Tuple[SignalInstance, tuple]
+SigArgTuple = Tuple["SignalInstance", tuple]
 SignalQueue = Queue[SigArgTuple]
 _GLOBAL_QUEUE: Queue[SigArgTuple] = Queue()
 

--- a/src/psygnal/_signal.py
+++ b/src/psygnal/_signal.py
@@ -914,10 +914,7 @@ class SignalInstance:
             # and we don't want to incur the overhead of creating it for every instance.
             if self._emit_queue is None:
                 self._emit_queue = Queue()
-            with self._lock:
-                self._emit_queue.put(
-                    (args, {"queue": False, "asynchronous": asynchronous})
-                )
+            self._emit_queue.put((args, {"queue": False, "asynchronous": asynchronous}))
             return None
 
         if asynchronous:
@@ -973,10 +970,9 @@ class SignalInstance:
         if self._emit_queue is None or self._emit_queue.empty():
             return
 
-        with self._lock:
-            while not self._emit_queue.empty():
-                args, kwargs = self._emit_queue.get()
-                self.emit(*args, **kwargs)
+        while not self._emit_queue.empty():
+            args, kwargs = self._emit_queue.get()
+            self.emit(*args, **kwargs)
 
     @overload
     def __call__(

--- a/src/psygnal/_signal.py
+++ b/src/psygnal/_signal.py
@@ -967,8 +967,8 @@ class SignalInstance:
         threading.Thread(target=_some_thread_that_emits).start()
         ```
         """
-        if self._emit_queue is None or self._emit_queue.empty():
-            return
+        if self._emit_queue is None:
+            return  # pragma: no cover
 
         while not self._emit_queue.empty():
             args, kwargs = self._emit_queue.get()

--- a/src/psygnal/_signal.py
+++ b/src/psygnal/_signal.py
@@ -953,10 +953,10 @@ class SignalInstance:
 
         # this timer lives in the main thread
         timer = QTimer()
-        timer.setTimerType(Qt.TimerType.PreciseTimer)
-        # connect the timer to the `emit_queued` method
+
+        # whenever the timer times out, it will call `emit_queued`
         timer.timeout.connect(obj.sig.emit_queued)
-        timer.start(0)
+        timer.start(0)  # start the timer
 
         def _some_thread_that_emits() -> None:
             # inside the thread call `emit()` with `queue=True`

--- a/tests/test_evented_model.py
+++ b/tests/test_evented_model.py
@@ -349,6 +349,10 @@ def test_defaults():
 
     default_r = R()
 
+    # this line forces the creation of the _emit_queue Queue object.
+    # this makes sure that we can still pickle the D model even with the Queue object.
+    default_r.events.x.emit("there", queue=True)
+
     class D(EventedModel):
         a: int = 1
         b: int = 1

--- a/tests/test_qt_compat.py
+++ b/tests/test_qt_compat.py
@@ -109,14 +109,16 @@ def test_q_main_thread_emit(qtbot: "QtBot") -> None:
     """
     from qtpy.QtCore import QTimer
 
+    from psygnal import emit_queued
+
     class C:
         sig = Signal(int)
 
     obj = C()
 
-    timer = QTimer()
-    timer.timeout.connect(obj.sig.emit_queued)
-    timer.start(0)
+    signal_relay = QTimer()
+    signal_relay.timeout.connect(emit_queued)
+    signal_relay.start(0)
 
     ARGS = (1,)
 


### PR DESCRIPTION
This PR attempts to provide a partial solution<sup>*</sup> to the problem of needing to have an emitter run in another thread (e.g. imagine a thread that polls some device and emits change events), while having the callbacks called in some other thread (like the main GUI thread in Qt for example).  One could certainly use [superqt thread workers](https://pyapp-kit.github.io/superqt/utilities/threading/?h=thread#superqt.utils.thread_worker), but this provides a slightly lower level (and possibly more performant?) solution.

signal instances now have a private `Queue` object, and the `emit` method gains a new `queue=...` argument, which is False by default.  When True, the emission does not occur immediately, but rather is added to the queue to be emitted at later when something calls `emit_queued` (currently, it is up to the user to call that in whatever thread they want).  So, an example using a QTimer to emit queued arguments in the main thread would be:

```python
from qtpy.QtCore import QTimer, Qt
from psygnal import Signal, emit_queued
import threading

class Emitter:
    sig = Signal(int)

obj = Emitter()

@obj.sig.connect
def on_emit(value: int):
    print(f"got value {value} from thread {threading.current_thread().name!r}")

# this timer lives in the main thread
timer = QTimer()

# whenever the timer times out, it will call `emit_queued`
timer.timeout.connect(emit_queued)
timer.start(0)  # start the timer

def _some_thread_that_emits() -> None:
    # inside the thread call `emit()` with `queue=True`
    obj.sig.emit(1, queue=True)

threading.Thread(target=_some_thread_that_emits).start()
```

@kephale, hopefully this will be useful for pulser.  @Czaki, if you have a moment to take a quick look, I'd appreciate your insights

----------- 

<sup>*</sup> I say "partial" solution because it's still up to the user to invoke the emission from the main thread.  So we haven't quite provided a complete solution to #198 ... but then again, I'm not sure we can do that entirely in psygnal.  Because psygnal itself doesn't manage an event loop, we can likely just "play nicely" with various event loop patterns