### PR TITLE
feat: add thread parameter to connection method, allowed "queued connections"

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,7 @@ docs = [
     "mkdocs==1.4.2",
     "mkdocstrings-python==0.8.3",
     "mkdocstrings==0.20.0",
-    "mkdocs-spellcheck[all]"
+    "mkdocs-spellcheck[all]",
 ]
 proxy = ["wrapt"]
 pydantic = ["pydantic"]
@@ -104,14 +104,12 @@ dependencies = [
     "types-attrs",
     "msgspec ; python_version >= '3.8'",
 ]
-include = [
-    "src/psygnal/_dataclass_utils.py",
-    "src/psygnal/_evented_decorator.py",
-    "src/psygnal/_group_descriptor.py",
-    "src/psygnal/_group.py",
-    "src/psygnal/_signal.py",
-    "src/psygnal/_throttler.py",
-    "src/psygnal/_weak_callback.py",
+exclude = [
+    "src/psygnal/__init__.py",
+    "src/psygnal/_evented_model.py",
+    "src/psygnal/utils.py",
+    "src/psygnal/containers",
+    "src/psygnal/_pyinstaller_util",
 ]
 
 [tool.cibuildwheel]
@@ -168,7 +166,7 @@ testpaths = ["tests"]
 filterwarnings = [
     "error",
     "ignore:The distutils package is deprecated:DeprecationWarning:",
-    "ignore:.*BackendFinder.find_spec()", # pyinstaller import
+    "ignore:.*BackendFinder.find_spec()",                             # pyinstaller import
 ]
 
 # https://mypy.readthedocs.io/en/stable/config_file.html

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,6 +109,7 @@ exclude = [
     "src/psygnal/_evented_model.py",
     "src/psygnal/utils.py",
     "src/psygnal/containers",
+    "src/psygnal/qt.py",
     "src/psygnal/_pyinstaller_util",
 ]
 

--- a/src/psygnal/__init__.py
+++ b/src/psygnal/__init__.py
@@ -34,6 +34,7 @@ __all__ = [
     "debounced",
     "EmissionInfo",
     "EmitLoopError",
+    "emit_queued",
     "evented",
     "EventedModel",
     "get_evented_namespace",
@@ -63,6 +64,7 @@ from ._group_descriptor import (
     get_evented_namespace,
     is_evented,
 )
+from ._queue import emit_queued
 from ._signal import EmitLoopError, Signal, SignalInstance, _compiled
 from ._throttler import debounced, throttled
 

--- a/src/psygnal/__init__.py
+++ b/src/psygnal/__init__.py
@@ -54,10 +54,12 @@ if os.getenv("PSYGNAL_UNCOMPILED"):
         "PSYGNAL_UNCOMPILED no longer has any effect. If you wish to run psygnal "
         "without compiled files, you can run:\n\n"
         'python -c "import psygnal.utils; psygnal.utils.decompile()"\n\n'
-        "(You will need to reinstall psygnal to get the compiled version back.)"
+        "(You will need to reinstall psygnal to get the compiled version back.)",
+        stacklevel=2,
     )
 
 from ._evented_decorator import evented
+from ._exceptions import EmitLoopError
 from ._group import EmissionInfo, SignalGroup
 from ._group_descriptor import (
     SignalGroupDescriptor,
@@ -65,7 +67,7 @@ from ._group_descriptor import (
     is_evented,
 )
 from ._queue import emit_queued
-from ._signal import EmitLoopError, Signal, SignalInstance, _compiled
+from ._signal import Signal, SignalInstance, _compiled
 from ._throttler import debounced, throttled
 
 

--- a/src/psygnal/_exceptions.py
+++ b/src/psygnal/_exceptions.py
@@ -1,0 +1,11 @@
+class EmitLoopError(Exception):
+    """Error type raised when an exception occurs during a callback."""
+
+    def __init__(self, slot_repr: str, args: tuple, exc: BaseException) -> None:
+        self.slot_repr = slot_repr
+        self.args = args
+        self.__cause__ = exc  # mypyc doesn't set this, but uncompiled code would
+        super().__init__(
+            f"calling {self.slot_repr} with args={args!r} caused "
+            f"{type(exc).__name__}: {exc}."
+        )

--- a/src/psygnal/_pyinstaller_util/hook-psygnal.py
+++ b/src/psygnal/_pyinstaller_util/hook-psygnal.py
@@ -24,7 +24,7 @@ def binary_files(file_list: Iterable[Union[PackagePath, Path]]) -> List[Path]:
 
 
 def create_hiddenimports() -> List[str]:
-    res = ["mypy_extensions", "__future__"]
+    res = ["queue", "mypy_extensions", "__future__"]
 
     try:
         files_list = package_files("psygnal")

--- a/src/psygnal/_queue.py
+++ b/src/psygnal/_queue.py
@@ -1,5 +1,5 @@
 from queue import Queue
-from typing import Any, Callable, Tuple
+from typing import Any, Callable, ClassVar, Tuple
 
 from ._weak_callback import WeakCallback
 
@@ -8,7 +8,7 @@ CbArgsTuple = Tuple[Callback, tuple]
 
 
 class QueuedCallback(WeakCallback):
-    _GLOBAL_QUEUE: Queue[CbArgsTuple] = Queue()
+    _GLOBAL_QUEUE: ClassVar[Queue[CbArgsTuple]] = Queue()
 
     def __init__(self, wrapped: WeakCallback) -> None:
         self._wrapped = wrapped
@@ -18,7 +18,7 @@ class QueuedCallback(WeakCallback):
         self._on_ref_error = wrapped._on_ref_error
 
     def cb(self, args: tuple = ()) -> None:
-        self._GLOBAL_QUEUE.put((self._wrapped.cb, args))
+        QueuedCallback._GLOBAL_QUEUE.put((self._wrapped.cb, args))
 
     def dereference(self) -> Callable | None:
         return self._wrapped.dereference()

--- a/src/psygnal/_queue.py
+++ b/src/psygnal/_queue.py
@@ -1,0 +1,35 @@
+from queue import Queue
+from typing import Any, Callable, Tuple
+
+from ._weak_callback import WeakCallback
+
+Callback = Callable[[tuple[Any, ...]], Any]
+CbArgsTuple = Tuple[Callback, tuple]
+
+
+class QueuedCallback(WeakCallback):
+    _GLOBAL_QUEUE: Queue[CbArgsTuple] = Queue()
+
+    def __init__(self, wrapped: WeakCallback) -> None:
+        self._wrapped = wrapped
+        self._key: str = wrapped._key
+        self._max_args: int | None = wrapped._max_args
+        self._alive: bool = wrapped._alive
+        self._on_ref_error = wrapped._on_ref_error
+
+    def cb(self, args: tuple = ()) -> None:
+        self._GLOBAL_QUEUE.put((self._wrapped.cb, args))
+
+    def dereference(self) -> Callable | None:
+        return self._wrapped.dereference()
+
+
+def emit_queued(queue: Queue[CbArgsTuple] = QueuedCallback._GLOBAL_QUEUE) -> None:
+    from ._signal import EmitLoopError
+
+    while not queue.empty():
+        cb, args = queue.get()
+        try:
+            cb(args)
+        except Exception as e:
+            raise EmitLoopError(slot_repr=repr(cb), args=args, exc=e) from e

--- a/src/psygnal/_queue.py
+++ b/src/psygnal/_queue.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from queue import Queue
-from threading import main_thread, Thread
+from threading import Thread, main_thread
 from typing import Any, Callable, ClassVar, Tuple
 
 from ._weak_callback import WeakCallback

--- a/src/psygnal/_queue.py
+++ b/src/psygnal/_queue.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
 from queue import Queue
-from threading import Thread, main_thread
-from typing import Any, Callable, ClassVar, Tuple
+from threading import Thread, current_thread, main_thread
+from typing import Any, Callable, ClassVar, DefaultDict, Tuple
 
+from ._exceptions import EmitLoopError
 from ._weak_callback import WeakCallback
 
 Callback = Callable[[Tuple[Any, ...]], Any]
@@ -11,15 +12,24 @@ CbArgsTuple = Tuple[Callback, tuple]
 
 
 class QueuedCallback(WeakCallback):
-    _GLOBAL_QUEUE: ClassVar[dict[Thread, Queue[CbArgsTuple]]] = defaultdict(Queue)
+    _GLOBAL_QUEUE: ClassVar[DefaultDict[Thread, Queue[CbArgsTuple]]] = DefaultDict(
+        Queue
+    )
 
-    def __init__(self, wrapped: WeakCallback, thread: Thread = main_thread()) -> None:
+    def __init__(self, wrapped: WeakCallback, thread: Thread | None = None) -> None:
         self._wrapped = wrapped
         self._key: str = wrapped._key
         self._max_args: int | None = wrapped._max_args
         self._alive: bool = wrapped._alive
         self._on_ref_error = wrapped._on_ref_error
-        self._thread = thread
+        if thread is None:
+            self._thread = main_thread()
+        elif not isinstance(thread, Thread):
+            raise TypeError(
+                f"thread must be a Thread instance, not {type(thread).__name__}"
+            )
+        else:
+            self._thread = thread
 
     def cb(self, args: tuple = ()) -> None:
         QueuedCallback._GLOBAL_QUEUE[self._thread].put((self._wrapped.cb, args))
@@ -28,12 +38,10 @@ class QueuedCallback(WeakCallback):
         return self._wrapped.dereference()
 
 
-def emit_queued(queue: Optional[Queue[CbArgsTuple]] = None) -> None:
-    pass
+def emit_queued(queue: Queue[CbArgsTuple] | None = None) -> None:
+    if queue is None:
+        queue = QueuedCallback._GLOBAL_QUEUE[current_thread()]
 
-
-if queue is None:
-    queue = QueuedCallback._GLOBAL_QUEUE[current_thread()]
     while not queue.empty():
         cb, args = queue.get()
         try:

--- a/src/psygnal/_queue.py
+++ b/src/psygnal/_queue.py
@@ -13,7 +13,7 @@ CbArgsTuple = Tuple[Callback, tuple]
 class QueuedCallback(WeakCallback):
     _GLOBAL_QUEUE: ClassVar[dict[Thread, Queue[CbArgsTuple]]] = defaultdict(Queue)
 
-    def __init__(self, wrapped: WeakCallback, thread: Thread = maint_thread()) -> None:
+    def __init__(self, wrapped: WeakCallback, thread: Thread = main_thread()) -> None:
         self._wrapped = wrapped
         self._key: str = wrapped._key
         self._max_args: int | None = wrapped._max_args

--- a/src/psygnal/_queue.py
+++ b/src/psygnal/_queue.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from queue import Queue
-from threading import main_thread, Thread
+from threading import Thread
 from typing import Any, Callable, ClassVar, Tuple
 
 from ._weak_callback import WeakCallback
@@ -28,7 +28,8 @@ class QueuedCallback(WeakCallback):
 
 
 def emit_queued(queue: Optional[Queue[CbArgsTuple]] = None) -> None:
-    from ._signal import EmitLoopError
+    pass
+
 
 if queue is None:
     queue = QueuedCallback._GLOBAL_QUEUE[current_thread()]

--- a/src/psygnal/_queue.py
+++ b/src/psygnal/_queue.py
@@ -12,39 +12,73 @@ CbArgsTuple = Tuple[Callback, tuple]
 
 
 class QueuedCallback(WeakCallback):
+    """WeakCallback that queues the callback to be called on a different thread.
+
+    (...rather than invoking it immediately.)
+
+    Parameters
+    ----------
+    wrapped : WeakCallback
+        The actual callback to be invoked.
+    thread : Thread, optional
+        The thread on which to invoke the callback.  If not provided, the main
+        thread will be used.
+    """
+
     _GLOBAL_QUEUE: ClassVar[DefaultDict[Thread, Queue[CbArgsTuple]]] = DefaultDict(
         Queue
     )
 
     def __init__(self, wrapped: WeakCallback, thread: Thread | None = None) -> None:
         self._wrapped = wrapped
+        # keeping the wrapped key allows this slot to be disconnected
+        # regardless of whether it was connected with type='queue' or 'direct' ...
         self._key: str = wrapped._key
         self._max_args: int | None = wrapped._max_args
         self._alive: bool = wrapped._alive
         self._on_ref_error = wrapped._on_ref_error
+
         if thread is None:
-            self._thread = main_thread()
-        elif not isinstance(thread, Thread):
+            thread = main_thread()
+        elif not isinstance(thread, Thread):  # pragma: no cover
             raise TypeError(
                 f"thread must be a Thread instance, not {type(thread).__name__}"
             )
-        else:
-            self._thread = thread
+        self._thread = thread
 
     def cb(self, args: tuple = ()) -> None:
-        QueuedCallback._GLOBAL_QUEUE[self._thread].put((self._wrapped.cb, args))
+        if current_thread() is self._thread:
+            self._wrapped.cb(args)
+        else:
+            QueuedCallback._GLOBAL_QUEUE[self._thread].put((self._wrapped.cb, args))
 
     def dereference(self) -> Callable | None:
         return self._wrapped.dereference()
 
 
-def emit_queued(queue: Queue[CbArgsTuple] | None = None) -> None:
-    if queue is None:
-        queue = QueuedCallback._GLOBAL_QUEUE[current_thread()]
+def emit_queued(thread: Thread | None = None) -> None:
+    """Trigger emissions of all callbacks queued in the current thread.
+
+    Parameters
+    ----------
+    thread : Thread, optional
+        The thread on which to invoke the callback.  If not provided, the main
+        thread will be used.
+
+    Raises
+    ------
+    EmitLoopError
+        If an exception is raised while invoking a queued callback.
+        This exception can be caught and optionally supressed or handled by the caller,
+        allowing the emission of other queued callbacks to continue even if one of them
+        raises an exception.
+    """
+    _thread = current_thread() if thread is None else thread
+    queue = QueuedCallback._GLOBAL_QUEUE[_thread]
 
     while not queue.empty():
         cb, args = queue.get()
         try:
             cb(args)
-        except Exception as e:
+        except Exception as e:  # pragma: no cover
             raise EmitLoopError(slot_repr=repr(cb), args=args, exc=e) from e

--- a/src/psygnal/_queue.py
+++ b/src/psygnal/_queue.py
@@ -1,9 +1,11 @@
+from __future__ import annotations
+
 from queue import Queue
 from typing import Any, Callable, ClassVar, Tuple
 
 from ._weak_callback import WeakCallback
 
-Callback = Callable[[tuple[Any, ...]], Any]
+Callback = Callable[[Tuple[Any, ...]], Any]
 CbArgsTuple = Tuple[Callback, tuple]
 
 

--- a/src/psygnal/_queue.py
+++ b/src/psygnal/_queue.py
@@ -2,7 +2,10 @@ from __future__ import annotations
 
 from queue import Queue
 from threading import Thread, current_thread, main_thread
-from typing import Any, Callable, ClassVar, DefaultDict, Tuple
+from typing import TYPE_CHECKING, Any, Callable, ClassVar, DefaultDict, Tuple
+
+if TYPE_CHECKING:
+    from typing_extensions import Literal
 
 from ._exceptions import EmitLoopError
 from ._weak_callback import WeakCallback
@@ -20,7 +23,7 @@ class QueuedCallback(WeakCallback):
     ----------
     wrapped : WeakCallback
         The actual callback to be invoked.
-    thread : Thread, optional
+    thread : Thread | Literal["main", "current"] | None
         The thread on which to invoke the callback.  If not provided, the main
         thread will be used.
     """
@@ -29,7 +32,11 @@ class QueuedCallback(WeakCallback):
         Queue
     )
 
-    def __init__(self, wrapped: WeakCallback, thread: Thread | None = None) -> None:
+    def __init__(
+        self,
+        wrapped: WeakCallback,
+        thread: Thread | Literal["main", "current"] | None = None,
+    ) -> None:
         self._wrapped = wrapped
         # keeping the wrapped key allows this slot to be disconnected
         # regardless of whether it was connected with type='queue' or 'direct' ...
@@ -38,11 +45,13 @@ class QueuedCallback(WeakCallback):
         self._alive: bool = wrapped._alive
         self._on_ref_error = wrapped._on_ref_error
 
-        if thread is None:
+        if thread is None or thread == "main":
             thread = main_thread()
+        elif thread == "current":
+            thread = current_thread()
         elif not isinstance(thread, Thread):  # pragma: no cover
             raise TypeError(
-                f"thread must be a Thread instance, not {type(thread).__name__}"
+                f"`thread` must be a Thread instance, not {type(thread).__name__}"
             )
         # NOTE: for some strange reason, mypyc crashes if we use `self._thread` here
         # so we use `self._thred` instead

--- a/src/psygnal/_queue.py
+++ b/src/psygnal/_queue.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from queue import Queue
-from threading import Thread
+from threading import main_thread, Thread
 from typing import Any, Callable, ClassVar, Tuple
 
 from ._weak_callback import WeakCallback

--- a/src/psygnal/_queue.py
+++ b/src/psygnal/_queue.py
@@ -44,13 +44,15 @@ class QueuedCallback(WeakCallback):
             raise TypeError(
                 f"thread must be a Thread instance, not {type(thread).__name__}"
             )
-        self._thread = thread
+        # NOTE: for some strange reason, mypyc crashes if we use `self._thread` here
+        # so we use `self._thred` instead
+        self._thred = thread
 
     def cb(self, args: tuple = ()) -> None:
-        if current_thread() is self._thread:
+        if current_thread() is self._thred:
             self._wrapped.cb(args)
         else:
-            QueuedCallback._GLOBAL_QUEUE[self._thread].put((self._wrapped.cb, args))
+            QueuedCallback._GLOBAL_QUEUE[self._thred].put((self._wrapped.cb, args))
 
     def dereference(self) -> Callable | None:
         return self._wrapped.dereference()

--- a/src/psygnal/_queue.py
+++ b/src/psygnal/_queue.py
@@ -19,6 +19,7 @@ class QueuedCallback(WeakCallback):
         self._max_args: int | None = wrapped._max_args
         self._alive: bool = wrapped._alive
         self._on_ref_error = wrapped._on_ref_error
+        self._thread = thread
 
     def cb(self, args: tuple = ()) -> None:
         QueuedCallback._GLOBAL_QUEUE[self._thread].put((self._wrapped.cb, args))

--- a/src/psygnal/_signal.py
+++ b/src/psygnal/_signal.py
@@ -340,7 +340,7 @@ class SignalInstance:
     def connect(
         self,
         *,
-        type: Literal["direct", "queued"] | threading.Thread = "direct",
+        type: Literal["direct", "queued"] | threading.Thread = ...,
         check_nargs: bool | None = ...,
         check_types: bool | None = ...,
         unique: bool | str = ...,
@@ -354,7 +354,7 @@ class SignalInstance:
         self,
         slot: F,
         *,
-        type: Literal["direct", "queued"] | threading.Thread = "direct",
+        type: Literal["direct", "queued"] | threading.Thread = ...,
         check_nargs: bool | None = ...,
         check_types: bool | None = ...,
         unique: bool | str = ...,
@@ -393,6 +393,13 @@ class SignalInstance:
             ...
         ```
 
+        !!!important
+
+            If a signal is connected with `type != 'direct'`, then it is up to the user
+            to ensure that `psygnal.emit_queued` is called, or that one of the backend
+            convenience functions is used (e.g. `psygnal.qt.start_emitting_from_queue`).
+            Otherwise, the slot will never be called.
+
         Parameters
         ----------
         slot : Callable
@@ -402,12 +409,14 @@ class SignalInstance:
         check_nargs : Optional[bool]
             If `True` and the provided `slot` requires more positional arguments than
             the signature of this Signal, raise `TypeError`. by default `True`.
-        type: {'direct', 'queued'} or Thread, optional
+        type: Literal["direct", "queued"] | threading.Thread
             If 'direct' (the default), this slot will be invoked immediately when a
-            signal is emitted.  If 'queued', invocation of this slot will be delayed
-            until the next time the main thread event loop is entered. If a thread
-            object is provided, then the event will be delayed to the next thread
-            event loop processing.
+            signal is emitted, from whatever thread emitted the signal.  If 'queued',
+            invocation of this slot will be delayed until the next time the main thread
+            event loop is entered. If a thread object is provided, then the event will
+            be added to a queue for that thread. If you connect a slot using `queued`
+            or a thread, then you must ensure that `psygnal.emit_queued` is called.
+            (See note above).
         check_types : Optional[bool]
             If `True`, An additional check will be performed to make sure that types
             declared in the slot signature are compatible with the signature

--- a/src/psygnal/_signal.py
+++ b/src/psygnal/_signal.py
@@ -356,7 +356,7 @@ class SignalInstance:
     def connect(
         self,
         *,
-        type: Union[Literal["direct", "queued"], Thread] = "direct",
+        type: Literal["direct", "queued"] | Thread = "direct",
         check_nargs: bool | None = ...,
         check_types: bool | None = ...,
         unique: bool | str = ...,
@@ -370,7 +370,7 @@ class SignalInstance:
         self,
         slot: F,
         *,
-        type: Union[Literal["direct", "queued"], Thread] = "direct",
+        type: Literal["direct", "queued"] | Thread = "direct",
         check_nargs: bool | None = ...,
         check_types: bool | None = ...,
         unique: bool | str = ...,
@@ -383,7 +383,7 @@ class SignalInstance:
         self,
         slot: F | None = None,
         *,
-        type: Union[Literal["direct", "queued"], Thread] = "direct",
+        type: Literal["direct", "queued"] | Thread = "direct",
         check_nargs: bool | None = None,
         check_types: bool | None = None,
         unique: bool | str = False,
@@ -421,9 +421,9 @@ class SignalInstance:
         type: {'direct', 'queued'} or Thread, optional
             If 'direct' (the default), this slot will be invoked immediately when a
             signal is emitted.  If 'queued', invocation of this slot will be delayed
-            until the next time the main thread event loop is entered. If a thread 
-            object is provided, then the event will be delayed to the next thread 
-            event loop processing. 
+            until the next time the main thread event loop is entered. If a thread
+            object is provided, then the event will be delayed to the next thread
+            event loop processing.
         check_types : Optional[bool]
             If `True`, An additional check will be performed to make sure that types
             declared in the slot signature are compatible with the signature

--- a/src/psygnal/qt.py
+++ b/src/psygnal/qt.py
@@ -13,7 +13,7 @@ from ._queue import emit_queued
 
 try:
     from qtpy.QtCore import Qt, QTimer
-except (ImportError, RuntimeError):
+except (ImportError, RuntimeError):  # pragma: no cover
     raise ImportError(
         "The psygnal.qt module requires qtpy and some Qt backend to be installed"
     ) from None

--- a/src/psygnal/qt.py
+++ b/src/psygnal/qt.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+try:
+    from qtpy.QtCore import Qt, QTimer
+except ImportError:
+    raise ImportError(
+        "The psygnal.qt module requires qtpy and some Qt backend to be installed"
+    ) from None
+
+_TIMER: QTimer | None = None
+
+
+def start_emitting_from_queue(
+    msec: int = 0, timer_type: Qt.TimerType = Qt.TimerType.PreciseTimer
+) -> None:
+    """Start a QTimer that will monitor the global emission queue.
+
+    When callbacks are connected to signals with `connect(type='queued')`, then they
+    are not invoked immediately, but rather added to a global queue.  This function
+    starts a QTimer that will periodically check the queue and invoke any callbacks
+    that are waiting to be invoked (in whatever thread this QTimer is running in).
+    """
+    global _TIMER
+
+    if _TIMER is None:
+        _TIMER = QTimer()
+        from ._queue import emit_queued
+
+        _TIMER.timeout.connect(emit_queued)
+
+    _TIMER.setTimerType(timer_type)
+    if _TIMER.isActive():
+        _TIMER.setInterval(msec)
+    else:
+        _TIMER.start(msec)
+
+
+def stop_emitting_from_queue() -> None:
+    """Stop the QTimer that monitors the global emission queue."""
+    global _TIMER
+    if _TIMER is not None:
+        _TIMER.stop()

--- a/src/psygnal/qt.py
+++ b/src/psygnal/qt.py
@@ -1,3 +1,10 @@
+"""Module that provides Qt-specific functionality for psygnal.
+
+This module provides convenience functions for starting and stopping a QTimer that
+will monitor "queued" signals and invoke their callbacks.  This is useful when
+psygnal is used in a Qt application, and you'd like to emit signals from a thread
+but have their callbacks invoked in the main thread.
+"""
 from __future__ import annotations
 
 from threading import Thread, current_thread
@@ -22,7 +29,8 @@ def start_emitting_from_queue(
     """Start a QTimer that will monitor the global emission queue.
 
     If a QTimer is already running in the current thread, then this function will
-    update the interval and timer type of that QTimer.
+    update the interval and timer type of that QTimer. (It is safe to call this
+    function multiple times in the same thread.)
 
     When callbacks are connected to signals with `connect(type='queued')`, then they
     are not invoked immediately, but rather added to a global queue.  This function

--- a/src/psygnal/qt.py
+++ b/src/psygnal/qt.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
-from threading import current_thread, Thread
+
+from threading import current_thread
 
 try:
     from qtpy.QtCore import Qt, QTimer

--- a/src/psygnal/qt.py
+++ b/src/psygnal/qt.py
@@ -13,7 +13,7 @@ from ._queue import emit_queued
 
 try:
     from qtpy.QtCore import Qt, QTimer
-except ImportError:
+except (ImportError, RuntimeError):
     raise ImportError(
         "The psygnal.qt module requires qtpy and some Qt backend to be installed"
     ) from None

--- a/src/psygnal/qt.py
+++ b/src/psygnal/qt.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
-from threading import current_thread
+from threading import Thread, current_thread
+
+from ._queue import emit_queued
 
 try:
     from qtpy.QtCore import Qt, QTimer
@@ -9,36 +11,58 @@ except ImportError:
         "The psygnal.qt module requires qtpy and some Qt backend to be installed"
     ) from None
 
-_TIMER: dict[Tread, QTimer] = {}
+_TIMERS: dict[Thread, QTimer] = {}
 
 
 def start_emitting_from_queue(
-    msec: int = 0, timer_type: Qt.TimerType = Qt.TimerType.PreciseTimer
+    msec: int = 0,
+    timer_type: Qt.TimerType = Qt.TimerType.PreciseTimer,
+    thread: Thread | None = None,
 ) -> None:
     """Start a QTimer that will monitor the global emission queue.
+
+    If a QTimer is already running in the current thread, then this function will
+    update the interval and timer type of that QTimer.
 
     When callbacks are connected to signals with `connect(type='queued')`, then they
     are not invoked immediately, but rather added to a global queue.  This function
     starts a QTimer that will periodically check the queue and invoke any callbacks
     that are waiting to be invoked (in whatever thread this QTimer is running in).
+
+    Parameters
+    ----------
+    msec : int, optional
+        The interval (in milliseconds) at which the QTimer will check the global
+        emission queue.  By default, the QTimer will check the queue as often as
+        possible (i.e. 0 milliseconds).
+    timer_type : Qt.TimerType, optional
+        The type of timer to use.  By default, Qt.PreciseTimer is used, which is
+        the most accurate timer available on the system.
+    thread : Thread, optional
+        The thread in which to start the QTimer.  By default, the QTimer will be
+        started in the thread from which this function is called.
     """
-    thread = current_thread()
-    if thread not in _TIMER:
-        _TIMER[thread] = QTimer()
-        from ._queue import emit_queued
+    _thread = current_thread() if thread is None else thread
+    if _thread not in _TIMERS:
+        _TIMERS[_thread] = QTimer()
 
-        _TIMER[thread].timeout.connect(emit_queued)
+        _TIMERS[_thread].timeout.connect(emit_queued)
 
-    _TIMER[thread].setTimerType(timer_type)
-    if _TIMER[thread].isActive():
-        _TIMER[thread].setInterval(msec)
+    _TIMERS[_thread].setTimerType(timer_type)
+    if _TIMERS[_thread].isActive():
+        _TIMERS[_thread].setInterval(msec)
     else:
-        _TIMER[thread].start(msec)
+        _TIMERS[_thread].start(msec)
 
 
-def stop_emitting_from_queue() -> None:
-    """Stop the QTimer that monitors the global emission queue."""
-    global _TIMER
-    timer = _TIMER.get(current_thread())
+def stop_emitting_from_queue(thread: Thread | None = None) -> None:
+    """Stop the QTimer that monitors the global emission queue.
+
+    thread : Thread, optional
+        The thread in which to stop the QTimer. By default, will stop any QTimers
+        in the thread from which this function is called.
+    """
+    _thread = current_thread() if thread is None else thread
+    timer = _TIMERS.get(_thread)
     if timer is not None:
         timer.stop()

--- a/tests/test_psygnal.py
+++ b/tests/test_psygnal.py
@@ -4,10 +4,11 @@ import time
 from contextlib import suppress
 from functools import partial, wraps
 from inspect import Signature
-from typing import Literal, Optional
+from typing import Optional
 from unittest.mock import MagicMock, Mock, call
 
 import pytest
+from typing_extensions import Literal
 
 from psygnal import EmitLoopError, Signal, SignalInstance, _compiled
 from psygnal._weak_callback import WeakCallback

--- a/tests/test_psygnal.py
+++ b/tests/test_psygnal.py
@@ -211,8 +211,8 @@ def test_nested_signal_blocked():
     mock.assert_called_once_with(3)
 
 
-@pytest.mark.parametrize("connect_type", ["direct", "queued"])
-def test_disconnect(connect_type: Literal["direct", "queued"]) -> None:
+@pytest.mark.parametrize("thread", [None, "main"])
+def test_disconnect(thread: Literal[None, "main"]) -> None:
     emitter = Emitter()
     mock = MagicMock()
     with pytest.raises(ValueError) as e:
@@ -220,9 +220,9 @@ def test_disconnect(connect_type: Literal["direct", "queued"]) -> None:
     assert "slot is not connected" in str(e)
     emitter.one_int.disconnect(mock)
 
-    emitter.one_int.connect(mock, type=connect_type)
+    emitter.one_int.connect(mock, thread=thread)
     assert len(emitter.one_int) == 1
-    if connect_type == "direct":
+    if thread is None:
         emitter.one_int.emit(1)
         mock.assert_called_once_with(1)
         mock.reset_mock()
@@ -862,12 +862,12 @@ def test_queued_connections():
     any_thread_mock = Mock()
 
     # mock1 wants to be called in this thread
-    @emitter.one_int.connect(type=this_thread)
+    @emitter.one_int.connect(thread=this_thread)
     def cb1(arg):
         this_thread_mock(arg, current_thread())
 
     # mock2 wants to be called in other_thread
-    @emitter.one_int.connect(type=other_thread)
+    @emitter.one_int.connect(thread=other_thread)
     def cb2(arg):
         other_thread_mock(arg, current_thread())
 

--- a/tests/test_pyinstaller_hook.py
+++ b/tests/test_pyinstaller_hook.py
@@ -4,6 +4,8 @@ import subprocess
 import warnings
 from pathlib import Path
 
+import pytest
+
 import psygnal
 
 
@@ -28,13 +30,12 @@ def test_hook_content():
 def test_pyintstaller_hiddenimports(tmp_path: Path) -> None:
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
-
-        from PyInstaller import __main__ as pyi_main
+        pyi_main = pytest.importorskip("PyInstaller.__main__")
 
     build_path = tmp_path / "build"
     dist_path = tmp_path / "dist"
     app_name = "psygnal_test"
-    app = tmp_path / (app_name + ".py")
+    app = tmp_path / f"{app_name}.py"
     app.write_text("\n".join(["import psygnal", "print(psygnal.__version__)"]))
 
     args = [

--- a/tests/test_qt_compat.py
+++ b/tests/test_qt_compat.py
@@ -8,7 +8,6 @@ from typing_extensions import Literal
 
 from psygnal import Signal
 from psygnal._signal import _guess_qtsignal_signature
-from psygnal.qt import stop_emitting_from_queue
 
 pytest.importorskip("pytestqt")
 if TYPE_CHECKING:
@@ -112,7 +111,7 @@ def test_q_main_thread_emit(
 
     ... and receiving it on the main thread with a QTimer connected to `emit_queued`
     """
-    from psygnal.qt import start_emitting_from_queue
+    from psygnal.qt import start_emitting_from_queue, stop_emitting_from_queue
 
     class C:
         sig = Signal(int)

--- a/tests/test_qt_compat.py
+++ b/tests/test_qt_compat.py
@@ -8,6 +8,7 @@ from typing_extensions import Literal
 
 from psygnal import Signal
 from psygnal._signal import _guess_qtsignal_signature
+from psygnal.qt import stop_emitting_from_queue
 
 pytest.importorskip("pytestqt")
 if TYPE_CHECKING:
@@ -141,3 +142,6 @@ def test_q_main_thread_emit(
         start_emitting_from_queue()
         qapp.processEvents()
         mock.assert_called_once_with(1)
+
+        start_emitting_from_queue(10)  # just for test coverage
+        stop_emitting_from_queue()

--- a/tests/test_weak_callable.py
+++ b/tests/test_weak_callable.py
@@ -166,4 +166,13 @@ def test_deref(strong: bool) -> None:
 
 
 def test_queued_callbacks():
-    ...
+    from psygnal._queue import QueuedCallback
+
+    def func(x):
+        return x
+
+    cb = weak_callback(func)
+    qcb = QueuedCallback(cb, thread="current")
+
+    assert qcb.dereference() is func
+    assert qcb(1) == 1

--- a/tests/test_weak_callable.py
+++ b/tests/test_weak_callable.py
@@ -163,3 +163,7 @@ def test_deref(strong: bool) -> None:
     assert dp.func is p.func
     assert dp.args == p.args
     assert dp.keywords == p.keywords
+
+
+def test_queued_callbacks():
+    ...


### PR DESCRIPTION
alternative to #199  ... hat-tip to @Czaki  for the inspiration.

somewhat closer to realizing #198 

run this script as an example
```python
import threading
from qtpy.QtWidgets import QApplication
from psygnal import Signal
# special qt support, so everyone can share the same main-thread timer
from psygnal.qt import start_emitting_from_queue 


class Emitter:
    sig = Signal(int)

obj = Emitter()

@obj.sig.connect(thread='main')
def on_emit(value: int) -> None:
    """Callback function that states its thread."""
    print(f"got value {value} from thread {threading.current_thread().name!r}")

app = QApplication([])
start_emitting_from_queue()
threading.Thread(target=obj.sig.emit, args=(1,)).start()
app.processEvents()
```

