### PR TITLE
chore: deprecate async keyword in emit method

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -230,8 +230,15 @@ obj.value_changed.emit(10)
 
 ## Asynchronous Signal Emission
 
-There is experimental support for calling all connected slots in another
-thread, using `emit(..., asynchronous=True)`
+!!!warning "Deprecated"
+
+    This feature is deprecated and will be removed in a future release.
+    Its use is not recommended in new code. If you need to emit signals
+    in a background thread, please create your own [`threading.Thread`][]
+    and call `emit` from within that thread.
+
+There is ~~experimental~~ **deprecated** support for calling all connected slots
+in another thread, using `emit(..., asynchronous=True)`
 
 ```py
 obj = MyObj()

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -62,6 +62,7 @@ markdown_extensions:
   - admonition
   - pymdownx.details
   - pymdownx.superfences
+  - pymdownx.tilde
   - pymdownx.tabbed:
       alternate_style: true
   - toc:

--- a/src/psygnal/_signal.py
+++ b/src/psygnal/_signal.py
@@ -911,10 +911,10 @@ class SignalInstance:
 
         if asynchronous:
             warnings.warn(
-                "The `asynchronous` parameter is deprecated. If you need this, please "
-                "create your own `threading.Thread` and call `SignalInstance.emit`."
-                "See also the new `thread` parameter in the `SignalInstance.connect` "
-                "method.",
+                "The `asynchronous` parameter is deprecated and will be removed in a "
+                "future release. If you need this, please create your own "
+                "`threading.Thread` and call `SignalInstance.emit`. See also the new "
+                "`thread` parameter in the `SignalInstance.connect` method.",
                 DeprecationWarning,
                 stacklevel=2,
             )

--- a/src/psygnal/_signal.py
+++ b/src/psygnal/_signal.py
@@ -915,7 +915,7 @@ class SignalInstance:
                 "future release. If you need this, please create your own "
                 "`threading.Thread` and call `SignalInstance.emit`. See also the new "
                 "`thread` parameter in the `SignalInstance.connect` method.",
-                DeprecationWarning,
+                FutureWarning,
                 stacklevel=2,
             )
             sd = EmitThread(self, args)

--- a/src/psygnal/_signal.py
+++ b/src/psygnal/_signal.py
@@ -857,16 +857,21 @@ class SignalInstance:
         *args : Any
             These arguments will be passed when calling each slot (unless the slot
             accepts fewer arguments, in which case extra args will be discarded.)
-        check_nargs : Optional[bool]
+        check_nargs : bool
             If `False` and the provided arguments cannot be successfully bound to the
             signature of this Signal, raise `TypeError`.  Incurs some overhead.
             by default False.
-        check_types : Optional[bool]
+        check_types : bool
             If `False` and the provided arguments do not match the types declared by
             the signature of this Signal, raise `TypeError`.  Incurs some overhead.
             by default False.
-        asynchronous : Optional[bool]
+        asynchronous : bool
             If `True`, run signal emission in another thread. by default `False`.
+            **DEPRECATED:**. *If you need to emit from a thread, please just create
+            your own [`threading.Thread`][] and call
+            [`SignalInstance.emit`][psygnal.SignalInstance.emit]. See also the `thread`
+            parameter in the [`SignalInstance.connect`][psygnal.SignalInstance.connect]
+            method.*
 
         Raises
         ------
@@ -905,6 +910,14 @@ class SignalInstance:
             SignalInstance._debug_hook(EmissionInfo(self, args))
 
         if asynchronous:
+            warnings.warn(
+                "The `asynchronous` parameter is deprecated. If you need this, please "
+                "create your own `threading.Thread` and call `SignalInstance.emit`."
+                "See also the new `thread` parameter in the `SignalInstance.connect` "
+                "method.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
             sd = EmitThread(self, args)
             sd.start()
             return sd

--- a/tests/test_psygnal.py
+++ b/tests/test_psygnal.py
@@ -573,7 +573,8 @@ def test_asynchronous_emit():
 
     assert not Signal.current_emitter()
     value = 42
-    thread = e.no_arg.emit(value, asynchronous=True)
+    with pytest.warns(FutureWarning):
+        thread = e.no_arg.emit(value, asynchronous=True)
     mock.assert_called_once()
     assert Signal.current_emitter() is e.no_arg
 


### PR DESCRIPTION
with #200 as  the preferred approach for dealing with signals across threads, this deprecates the `asynchronous` keyword to `emit.`