### PR TITLE
fix: better error message with keyword only partials

### DIFF
--- a/tests/test_psygnal.py
+++ b/tests/test_psygnal.py
@@ -234,7 +234,16 @@ def test_disconnect(thread: Literal[None, "main"]) -> None:
 
 
 @pytest.mark.parametrize(
-    "type_", ["function", "lambda", "method", "partial_method", "setattr", "setitem"]
+    "type_",
+    [
+        "function",
+        "lambda",
+        "method",
+        "partial_method",
+        "partial_method_kwarg",
+        "setattr",
+        "setitem",
+    ],
 )
 def test_slot_types(type_: str) -> None:
     emitter = Emitter()
@@ -254,6 +263,11 @@ def test_slot_types(type_: str) -> None:
         signal.connect(obj.f_int)
     elif type_ == "partial_method":
         signal.connect(partial(obj.f_int_int, 2))
+    elif type_ == "partial_method_kwarg":
+        signal.connect(partial(obj.f_int_int, b=2))
+    elif type_ == "partial_method_kwarg_bad":
+        with pytest.raises(ValueError, match="*prefer using positional args*"):
+            signal.connect(partial(obj.f_int_int, a=2))
 
     assert len(signal) == 1
 
@@ -538,7 +552,7 @@ def test_keyword_only_not_allowed():
 
     with pytest.raises(ValueError) as er:
         e.two_int.connect(f)
-    assert "Required KEYWORD_ONLY parameters not allowed" in str(er)
+    assert "Unsupported KEYWORD_ONLY parameters in signature" in str(er)
 
 
 def test_unique_connections():
@@ -818,6 +832,7 @@ def test_emit_loop_exceptions():
         "f_int_decorated_good",
         "f_any_assigned",
         "partial",
+        "partial_kwargs",
         pytest.param(
             "partial",
             marks=pytest.mark.xfail(
@@ -833,7 +848,12 @@ def test_weakref_disconnect(slot):
     obj = MyObj()
 
     assert len(emitter.one_int) == 0
-    cb = partial(obj.f_int_int, 1) if slot == "partial" else getattr(obj, slot)
+    if slot == "partial":
+        cb = partial(obj.f_int_int, 1)
+    elif slot == "partial_kwargs":
+        cb = partial(obj.f_int_int, b=1)
+    else:
+        cb = getattr(obj, slot)
     emitter.one_int.connect(cb)
     assert len(emitter.one_int) == 1
     emitter.one_int.emit(1)

--- a/tests/test_psygnal.py
+++ b/tests/test_psygnal.py
@@ -241,6 +241,7 @@ def test_disconnect(thread: Literal[None, "main"]) -> None:
         "method",
         "partial_method",
         "partial_method_kwarg",
+        "partial_method_kwarg_bad",
         "setattr",
         "setitem",
     ],
@@ -266,8 +267,9 @@ def test_slot_types(type_: str) -> None:
     elif type_ == "partial_method_kwarg":
         signal.connect(partial(obj.f_int_int, b=2))
     elif type_ == "partial_method_kwarg_bad":
-        with pytest.raises(ValueError, match="*prefer using positional args*"):
+        with pytest.raises(ValueError, match=".*prefer using positional args"):
             signal.connect(partial(obj.f_int_int, a=2))
+        return
 
     assert len(signal) == 1
 


### PR DESCRIPTION
it's possible using `functools.partials` to create required keyword-only arguments without paying attention:

```py
def f(a, b): ...

f2 = partial(f, a=1)  # b is now a required keyword argument
```

```pytb
In [5]: f2(3)
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
Cell In[5], line 1
----> 1 f2(3)

TypeError: f() got multiple values for argument 'a'
```

These are particularly hard for a callback system, and aren't currently supported by psygnal.  This PR just makes the error message a bit clearer if the user stumbles into this use case