### PR TITLE
fix: fix signature inspection on debounced/throttled, update typing and wrapped

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,6 +115,7 @@ exclude = [
     "src/psygnal/containers",
     "src/psygnal/qt.py",
     "src/psygnal/_pyinstaller_util",
+    "src/psygnal/_throttler.py",
 ]
 
 [tool.cibuildwheel]

--- a/src/psygnal/_throttler.py
+++ b/src/psygnal/_throttler.py
@@ -32,7 +32,7 @@ class _ThrottlerBase:
 
         # this mimics what functools.wraps does, but avoids __dict__ usage and other
         # things that won't work with mypyc... HOWEVER, most of these dynamic
-        # assignments won't work in mypyc anyway
+        # assignments won't work in mypyc anyway (they just do nothing.)
         self.__module__: str = getattr(func, "__module__", "")
         self.__name__: str = getattr(func, "__name__", "")
         self.__qualname__: str = getattr(func, "__qualname__", "")

--- a/src/psygnal/_throttler.py
+++ b/src/psygnal/_throttler.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from threading import Timer
-from typing import TYPE_CHECKING, Any, Callable, Generic
+from typing import TYPE_CHECKING, Any, Callable, Generic, TypeVar
 
 if TYPE_CHECKING:
     import inspect
@@ -12,9 +12,13 @@ if TYPE_CHECKING:
     EmissionPolicy = Literal["trailing", "leading"]
 
     P = ParamSpec("P")
+else:
+    # just so that we don't have to depend on a new version of typing_extensions
+    # at runtime
+    P = TypeVar("P")
 
 
-class _ThrottlerBase(Generic["P"]):
+class _ThrottlerBase(Generic[P]):
     _timer: Timer
 
     def __init__(
@@ -74,7 +78,7 @@ class _ThrottlerBase(Generic["P"]):
         return inspect.signature(self.__wrapped__)
 
 
-class Throttler(_ThrottlerBase, Generic["P"]):
+class Throttler(_ThrottlerBase, Generic[P]):
     """Class that prevents calling `func` more than once per `interval`.
 
     Parameters
@@ -112,7 +116,7 @@ class Throttler(_ThrottlerBase, Generic["P"]):
                 self._start_timer()
 
 
-class Debouncer(_ThrottlerBase, Generic["P"]):
+class Debouncer(_ThrottlerBase, Generic[P]):
     """Class that waits at least `interval` before calling `func`.
 
     Parameters

--- a/tests/test_throttler.py
+++ b/tests/test_throttler.py
@@ -89,7 +89,7 @@ def test_flush() -> None:
 def test_throttled_debounced_signature(deco: Callable) -> None:
     mock = Mock()
 
-    @deco(timeout=0)
+    @deco(timeout=0, leading=True)
     def f1(x: int) -> None:
         """Doc."""
         mock(x)
@@ -103,7 +103,6 @@ def test_throttled_debounced_signature(deco: Callable) -> None:
     sig = SignalInstance((int, int, int))
     sig.connect(f1)
     sig.emit(1, 2, 3)
-    time.sleep(0.1)
     mock.assert_called_once_with(1)
 
     if not _compiled:


### PR DESCRIPTION
in [mypyc's words](https://mypyc.readthedocs.io/en/latest/differences_from_python.html#introspection): "`inspect.signature` chokes on compiled functions"... which is a bummer for throttled/debounced if we're going to use them as callbacks (which is their main goal).

This PR fixes https://github.com/napari/napari/issues/6149#issuecomment-1678081559 by telling inspect.signature how to get to the wrapped function.  I think it should be good enough, but if more problems arise, we can just skip mypyc compilation on these modules.

cc @andy-sweet

*edit*: i just decided not to compile that module for now. 