### PR TITLE
feat: better repr for WeakCallback objects

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -94,6 +94,7 @@ jobs:
           HATCH_BUILD_HOOKS_ENABLE: "1"
 
       - name: test compiled
+        if: matrix.python-version != '3.12-dev'
         uses: aganders3/headless-gui@v1
         with:
           run: pytest --color=yes --cov=psygnal --cov-report=xml --cov-append

--- a/benchmarks/_evented.py
+++ b/benchmarks/_evented.py
@@ -7,7 +7,7 @@ from typing import ClassVar
 try:
     from psygnal import SignalGroupDescriptor
 except ImportError:
-    SignalGroupDescriptor = None
+    SignalGroupDescriptor = None  # type: ignore [misc,assignment]
 
 
 def _get_dataclass(type_: str, evented: bool) -> type:

--- a/src/psygnal/_signal.py
+++ b/src/psygnal/_signal.py
@@ -30,10 +30,10 @@ from typing_extensions import get_args, get_origin
 from ._exceptions import EmitLoopError
 from ._queue import QueuedCallback
 from ._weak_callback import (
+    StrongFunction,
     WeakCallback,
-    _StrongFunction,
-    _WeakSetattr,
-    _WeakSetitem,
+    WeakSetattr,
+    WeakSetitem,
     weak_callback,
 )
 
@@ -597,7 +597,7 @@ class SignalInstance:
             raise AttributeError(f"Object {obj} has no attribute {attr!r}")
 
         with self._lock:
-            caller = _WeakSetattr(
+            caller = WeakSetattr(
                 obj,
                 attr,
                 max_args=maxargs,
@@ -630,7 +630,7 @@ class SignalInstance:
         """
         # sourcery skip: merge-nested-ifs, use-next
         with self._lock:
-            cb = _WeakSetattr(obj, attr, on_ref_error="ignore")
+            cb = WeakSetattr(obj, attr, on_ref_error="ignore")
             self._try_discard(cb, missing_ok)
 
     def connect_setitem(
@@ -701,7 +701,7 @@ class SignalInstance:
             raise TypeError(f"Object {obj} does not support __setitem__")
 
         with self._lock:
-            caller = _WeakSetitem(
+            caller = WeakSetitem(
                 obj,  # type: ignore
                 key,
                 max_args=maxargs,
@@ -738,7 +738,7 @@ class SignalInstance:
 
         # sourcery skip: merge-nested-ifs, use-next
         with self._lock:
-            caller = _WeakSetitem(obj, key, on_ref_error="ignore")
+            caller = WeakSetitem(obj, key, on_ref_error="ignore")
             self._try_discard(caller, missing_ok)
 
     def _check_nargs(
@@ -1124,7 +1124,7 @@ class SignalInstance:
         )
         dd = {slot: getattr(self, slot) for slot in attrs}
         dd["_instance"] = self._instance()
-        dd["_slots"] = [x for x in self._slots if isinstance(x, _StrongFunction)]
+        dd["_slots"] = [x for x in self._slots if isinstance(x, StrongFunction)]
         if len(self._slots) > len(dd["_slots"]):
             warnings.warn(
                 "Pickling a SignalInstance does not copy connected weakly referenced "

--- a/tests/test_weak_callable.py
+++ b/tests/test_weak_callable.py
@@ -81,6 +81,9 @@ def test_slot_types(type_: str, capsys) -> None:
     elif type_ == "print":
         cb = weak_callback(print, finalize=final_mock)
 
+    print(cb)
+    return
+
     assert isinstance(cb, WeakCallback)
     cb.cb((2,))
     assert cb.dereference() is not None

--- a/tests/test_weak_callable.py
+++ b/tests/test_weak_callable.py
@@ -81,9 +81,6 @@ def test_slot_types(type_: str, capsys) -> None:
     elif type_ == "print":
         cb = weak_callback(print, finalize=final_mock)
 
-    print(cb)
-    return
-
     assert isinstance(cb, WeakCallback)
     cb.cb((2,))
     assert cb.dereference() is not None


### PR DESCRIPTION
for easier debugging

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- Refactor: Updated import statements and class names in `src/psygnal/_signal.py` and `src/psygnal/_weak_callback.py` for improved consistency and clarity.
- New Feature: Added `object_repr()` method to the `WeakCallback` class in `src/psygnal/_weak_callback.py` to provide a human-readable representation of an object.
- Test: Introduced a new print statement in `tests/test_weak_callable.py` for better debugging during testing.
- Chore: Added a conditional step in the CI/CD pipeline `.github/workflows/test.yml` to run tests using a headless GUI, improving test coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->