### PR TITLE
feat: emit the old value as second argument in Signals from SignalGroupDescriptor (evented dataclass)

### DIFF
--- a/src/psygnal/_evented_decorator.py
+++ b/src/psygnal/_evented_decorator.py
@@ -32,7 +32,6 @@ def evented(
     equality_operators: Optional[Dict[str, EqOperator]] = None,
     warn_on_no_fields: bool = ...,
     cache_on_instance: bool = ...,
-    emit_old_value: bool = ...,
 ) -> T:
     ...
 
@@ -45,7 +44,6 @@ def evented(
     equality_operators: Optional[Dict[str, EqOperator]] = None,
     warn_on_no_fields: bool = ...,
     cache_on_instance: bool = ...,
-    emit_old_value: bool = ...,
 ) -> Callable[[T], T]:
     ...
 
@@ -57,7 +55,6 @@ def evented(
     equality_operators: Optional[Dict[str, EqOperator]] = None,
     warn_on_no_fields: bool = True,
     cache_on_instance: bool = True,
-    emit_old_value: bool = False,
 ) -> Union[Callable[[T], T], T]:
     """A decorator to add events to a dataclass.
 
@@ -97,9 +94,6 @@ def evented(
         access, but means that the owner instance will no longer be pickleable.  If
         `False`, the SignalGroup instance will *still* be cached, but not on the
         instance itself.
-    emit_old_value: bool
-        When the field is mutated, emit two parameters, the new value and the old value, by
-        default False
 
     Returns
     -------
@@ -134,7 +128,6 @@ def evented(
             equality_operators=equality_operators,
             warn_on_no_fields=warn_on_no_fields,
             cache_on_instance=cache_on_instance,
-            emit_old_value=emit_old_value,
         )
         # as a decorator, this will have already been called
         descriptor.__set_name__(cls, events_namespace)

--- a/src/psygnal/_evented_decorator.py
+++ b/src/psygnal/_evented_decorator.py
@@ -32,6 +32,7 @@ def evented(
     equality_operators: Optional[Dict[str, EqOperator]] = None,
     warn_on_no_fields: bool = ...,
     cache_on_instance: bool = ...,
+    emit_old_value: bool = ...,
 ) -> T:
     ...
 
@@ -44,6 +45,7 @@ def evented(
     equality_operators: Optional[Dict[str, EqOperator]] = None,
     warn_on_no_fields: bool = ...,
     cache_on_instance: bool = ...,
+    emit_old_value: bool = ...,
 ) -> Callable[[T], T]:
     ...
 
@@ -55,6 +57,7 @@ def evented(
     equality_operators: Optional[Dict[str, EqOperator]] = None,
     warn_on_no_fields: bool = True,
     cache_on_instance: bool = True,
+    emit_old_value: bool = False,
 ) -> Union[Callable[[T], T], T]:
     """A decorator to add events to a dataclass.
 
@@ -94,6 +97,9 @@ def evented(
         access, but means that the owner instance will no longer be pickleable.  If
         `False`, the SignalGroup instance will *still* be cached, but not on the
         instance itself.
+    emit_old_value: bool
+        When the field is mutated, emit two parameters, the new value and the old value, by
+        default False
 
     Returns
     -------
@@ -128,6 +134,7 @@ def evented(
             equality_operators=equality_operators,
             warn_on_no_fields=warn_on_no_fields,
             cache_on_instance=cache_on_instance,
+            emit_old_value=emit_old_value,
         )
         # as a decorator, this will have already been called
         descriptor.__set_name__(cls, events_namespace)

--- a/src/psygnal/_group_descriptor.py
+++ b/src/psygnal/_group_descriptor.py
@@ -176,13 +176,7 @@ def get_evented_namespace(obj: object) -> str | None:
 
 
 class _changes_emitted:
-    def __init__(
-        self,
-        obj: object,
-        field: str,
-        signal: SignalInstance,
-        emit_old_value: bool = False,
-    ) -> None:
+    def __init__(self, obj: object, field: str, signal: SignalInstance) -> None:
         self.obj = obj
         self.field = field
         self.signal = signal
@@ -201,25 +195,19 @@ SetAttr = Callable[[Any, str, Any], None]
 
 
 @overload
-def evented_setattr(
-    signal_group_name: str, super_setattr: SetAttr, emit_old_value: bool = False
-) -> SetAttr:
+def evented_setattr(signal_group_name: str, super_setattr: SetAttr) -> SetAttr:
     ...
 
 
 @overload
 def evented_setattr(
-    signal_group_name: str,
-    super_setattr: Literal[None] | None = None,
-    emit_old_value: bool = False,
+    signal_group_name: str, super_setattr: Literal[None] | None = None
 ) -> Callable[[SetAttr], SetAttr]:
     ...
 
 
 def evented_setattr(
-    signal_group_name: str,
-    super_setattr: SetAttr | None = None,
-    emit_old_value: bool = False,
+    signal_group_name: str, super_setattr: SetAttr | None = None
 ) -> SetAttr | Callable[[SetAttr], SetAttr]:
     """Create a new __setattr__ method that emits events when fields change.
 

--- a/src/psygnal/_group_descriptor.py
+++ b/src/psygnal/_group_descriptor.py
@@ -176,7 +176,13 @@ def get_evented_namespace(obj: object) -> str | None:
 
 
 class _changes_emitted:
-    def __init__(self, obj: object, field: str, signal: SignalInstance, emit_old_value: bool = False) -> None:
+    def __init__(
+        self,
+        obj: object,
+        field: str,
+        signal: SignalInstance,
+        emit_old_value: bool = False,
+    ) -> None:
         self.obj = obj
         self.field = field
         self.signal = signal
@@ -198,19 +204,25 @@ SetAttr = Callable[[Any, str, Any], None]
 
 
 @overload
-def evented_setattr(signal_group_name: str, super_setattr: SetAttr, emit_old_value: bool = False) -> SetAttr:
+def evented_setattr(
+    signal_group_name: str, super_setattr: SetAttr, emit_old_value: bool = False
+) -> SetAttr:
     ...
 
 
 @overload
 def evented_setattr(
-    signal_group_name: str, super_setattr: Literal[None] | None = None, emit_old_value: bool = False
+    signal_group_name: str,
+    super_setattr: Literal[None] | None = None,
+    emit_old_value: bool = False,
 ) -> Callable[[SetAttr], SetAttr]:
     ...
 
 
 def evented_setattr(
-    signal_group_name: str, super_setattr: SetAttr | None = None, emit_old_value: bool = False
+    signal_group_name: str,
+    super_setattr: SetAttr | None = None,
+    emit_old_value: bool = False,
 ) -> SetAttr | Callable[[SetAttr], SetAttr]:
     """Create a new __setattr__ method that emits events when fields change.
 

--- a/src/psygnal/_group_descriptor.py
+++ b/src/psygnal/_group_descriptor.py
@@ -194,10 +194,7 @@ class _changes_emitted:
     def __exit__(self, *args: Any) -> None:
         new: Any = getattr(self.obj, self.field, _NULL)
         if not _check_field_equality(type(self.obj), self.field, self._prev, new):
-            if self.emit_old_value:
-                self.signal.emit(new, self._prev)
-            else:
-                self.signal.emit(new)
+            self.signal.emit(new, self._prev)
 
 
 SetAttr = Callable[[Any, str, Any], None]

--- a/src/psygnal/_group_descriptor.py
+++ b/src/psygnal/_group_descriptor.py
@@ -140,7 +140,8 @@ def _build_dataclass_signal_group(
             eq_map[name] = _equality_operators[name]
         else:
             eq_map[name] = _pick_equality_operator(type_)
-        signals[name] = Signal(object if type_ is None else type_)
+        field_type = object if type_ is None else type_
+        signals[name] = Signal(field_type, field_type)
 
     return type(f"{cls.__name__}SignalGroup", (SignalGroup,), signals)
 

--- a/tests/test_bench.py
+++ b/tests/test_bench.py
@@ -24,6 +24,7 @@ CALLBACK_TYPES = [
     "print",
 ]
 
+
 # fmt: off
 class Emitter:
     one_int = Signal(int)
@@ -221,6 +222,9 @@ def test_dataclass_setattr(type_: str, benchmark: Callable) -> None:
         foo.e = (2, "hello")
 
     benchmark(_doit)
-    for newval, attr in zip([2, "hello", False, 2.0, (2, "hello")], "abcde"):
-        mock.assert_any_call(EmissionInfo(getattr(foo.events, attr), (newval,)))
-        assert getattr(foo, attr) == newval
+    for emitted, attr in zip(
+        [(2, 1), ("hello", "hi"), (False, True), (2.0, 1.0), ((2, "hello"), (1, "hi"))],
+        "abcde",
+    ):
+        mock.assert_any_call(EmissionInfo(getattr(foo.events, attr), emitted))
+        assert getattr(foo, attr) == emitted[0]

--- a/tests/test_evented_decorator.py
+++ b/tests/test_evented_decorator.py
@@ -45,7 +45,7 @@ def _check_events(cls, events_ns="events"):
     assert obj.bar == 1
     obj.bar = 2
     assert obj.bar == 2
-    mock.assert_called_once_with(2)
+    mock.assert_called_once_with(2, 1)
 
     mock.reset_mock()
     obj.baz = "3"


### PR DESCRIPTION
I'm using `SignalGroupDescriptor` (or `evented`) with an `attrs` dataclass and I would like the change signal to emit the old value alongside the new value when mutated. 
It's a minimal change to allow that, in `_evented_decorator._changes_emitted` method `__exit__`, just change:
`self.signal.emit(new)`  --> `self.signal.emit(new, self._prev)`

I put the old value in second place because it should allow to connect to slots defined with only the new value as argument.

However, in order to not be a disturbing change, it would be better if it is opt-in.

That is this PR. It is working, but not with subclassing.
Any idea?

```python

import numpy as np
from psygnal import evented, Signal, EmissionInfo
from attrs import asdict, define, make_class, Factory, field, cmp_using

@evented(emit_old_value=True)
@define
class Person:
    name: str
    age: int = 0
    image: np.ndarray = field(eq=cmp_using(eq=np.array_equal), factory=lambda: np.array([]))

@evented(emit_old_value=False)
@define
class Dog:
    age: int

@evented(emit_old_value=False)
@define
class SuperWoman(Person):
    prize: bool = False

john = Person(name="John", age=30)
doug = Dog(age=2)
bridget = SuperWoman(name="Bridget", prize=True, age=None)

@john.events.connect
def on_any_change(info: EmissionInfo):
    print(f"field {info.signal.name!r} changed to {info.args}")

@doug.events.connect
def on_any_change(info: EmissionInfo):
    print(f"field {info.signal.name!r} changed to {info.args}")

@bridget.events.connect
def on_any_change(info: EmissionInfo):
    print(f"field {info.signal.name!r} changed to {info.args}")

# Emit old value
john.age = 21   # Works -> field 'age' changed to (21, 30)
# Do not emit old value
doug.age = 3   # Works -> field 'age' changed to (3,)

# Subclass does not emit old value (but superclass does)
bridget.age = 23  # NOT WORKING (arguably) -> field 'age' changed to (23, None)
bridget.prize = False  # NOT WORKING -> field 'prize' changed to (False, True)
```