### PR TITLE
fix: fix connect_setattr on dataclass field signals

### DIFF
--- a/src/psygnal/_group_descriptor.py
+++ b/src/psygnal/_group_descriptor.py
@@ -146,6 +146,7 @@ def _build_dataclass_signal_group(
     _equality_operators = dict(equality_operators) if equality_operators else {}
     signals = {}
     eq_map = _get_eq_operator_map(cls)
+    # create a Signal for each field in the dataclass
     for name, type_ in iter_fields(cls):
         if name in _equality_operators:
             if not callable(_equality_operators[name]):  # pragma: no cover
@@ -153,9 +154,10 @@ def _build_dataclass_signal_group(
             eq_map[name] = _equality_operators[name]
         else:
             eq_map[name] = _pick_equality_operator(type_)
-        sig = Signal(object if type_ is None else type_)
+        field_type = object if type_ is None else type_
+        signals[name] = sig = Signal(field_type)
+        # patch in our custom SignalInstance class with maxargs=1 on connect_setattr
         sig._signal_instance_class = _DataclassFieldSignalInstance
-        signals[name] = sig
 
     return type(f"{cls.__name__}SignalGroup", (SignalGroup,), signals)
 

--- a/src/psygnal/_group_descriptor.py
+++ b/src/psygnal/_group_descriptor.py
@@ -397,7 +397,7 @@ class SignalGroupDescriptor:
         try:
             # assign a new __setattr__ method to the class
             owner.__setattr__ = evented_setattr(  # type: ignore
-                self._name,
+                cast(str, self._name),
                 owner.__setattr__,  # type: ignore
             )
         except Exception as e:  # pragma: no cover

--- a/src/psygnal/_signal.py
+++ b/src/psygnal/_signal.py
@@ -116,6 +116,7 @@ class Signal:
         self.description = description
         self._check_nargs_on_connect = check_nargs_on_connect
         self._check_types_on_connect = check_types_on_connect
+        self._signal_instance_class: type[SignalInstance] = SignalInstance
 
         if types and isinstance(types[0], Signature):
             self._signature = types[0]
@@ -171,7 +172,7 @@ class Signal:
         if instance is None:
             return self
         name = cast("str", self._name)
-        signal_instance = SignalInstance(
+        signal_instance = self._signal_instance_class(
             self.signature,
             instance=instance,
             name=name,


### PR DESCRIPTION
This is a patch that will help #257: it sets the default `maxargs` to `1` for the `setattr_method` of all `SignalInstance` created in evented dataclasses.  this is probably the expected behavior anyway, since all signals on an evented dataclass usually emit only the value of that field 