### PR TITLE
chore: add future warning for maxargs in connect_setattr/setitem

### DIFF
--- a/src/psygnal/_group_descriptor.py
+++ b/src/psygnal/_group_descriptor.py
@@ -131,7 +131,7 @@ class _DataclassFieldSignalInstance(SignalInstance):
         self,
         obj: ref | object,
         attr: str,
-        maxargs: int | None = 1,
+        maxargs: int | None | object = 1,
         *,
         on_ref_error: RefErrorChoice = "warn",
     ) -> WeakCallback[None]:

--- a/src/psygnal/_signal.py
+++ b/src/psygnal/_signal.py
@@ -529,7 +529,7 @@ class SignalInstance:
         self,
         obj: weakref.ref | object,
         attr: str,
-        maxargs: int | None = None,
+        maxargs: int | None = _NULL,  # type: ignore
         *,
         on_ref_error: RefErrorChoice = "warn",
     ) -> WeakCallback[None]:
@@ -583,6 +583,16 @@ class SignalInstance:
         >>> t.sig.emit(5)
         >>> assert my_obj.x == 5
         """
+        if maxargs is _NULL:
+            warnings.warn(
+                "The default value of maxargs will change from `None` to `1` in"
+                "version 0.11. To silence this warning, provide an explicit value for "
+                "maxargs (`None` for current behavior, `1` for future behavior).",
+                FutureWarning,
+                stacklevel=2,
+            )
+            maxargs = None
+
         if isinstance(obj, weakref.ReferenceType):  # pragma: no cover
             warnings.warn(
                 'Using a weakref as the "obj" argument is deprecated. '
@@ -636,7 +646,7 @@ class SignalInstance:
         self,
         obj: weakref.ref | object,
         key: str,
-        maxargs: int | None = None,
+        maxargs: int | None = _NULL,  # type: ignore
         *,
         on_ref_error: RefErrorChoice = "warn",
     ) -> WeakCallback[None]:
@@ -687,6 +697,16 @@ class SignalInstance:
         >>> t.sig.emit(5)
         >>> assert my_obj == {'x': 5}
         """
+        if maxargs is _NULL:
+            warnings.warn(
+                "The default value of maxargs will change from `None` to `1` in"
+                "version 0.11. To silence this warning, provide an explicit value for "
+                "maxargs (`None` for current behavior, `1` for future behavior).",
+                FutureWarning,
+                stacklevel=2,
+            )
+            maxargs = None
+
         if isinstance(obj, weakref.ReferenceType):  # pragma: no cover
             warnings.warn(
                 'Using a weakref as the "obj" argument is deprecated. '

--- a/src/psygnal/_signal.py
+++ b/src/psygnal/_signal.py
@@ -529,7 +529,7 @@ class SignalInstance:
         self,
         obj: weakref.ref | object,
         attr: str,
-        maxargs: int | None = _NULL,  # type: ignore
+        maxargs: int | None | object = _NULL,
         *,
         on_ref_error: RefErrorChoice = "warn",
     ) -> WeakCallback[None]:
@@ -609,7 +609,7 @@ class SignalInstance:
             caller = WeakSetattr(
                 obj,
                 attr,
-                max_args=maxargs,
+                max_args=cast("int | None", maxargs),
                 finalize=self._try_discard,
                 on_ref_error=on_ref_error,
             )
@@ -646,7 +646,7 @@ class SignalInstance:
         self,
         obj: weakref.ref | object,
         key: str,
-        maxargs: int | None = _NULL,  # type: ignore
+        maxargs: int | None | object = _NULL,
         *,
         on_ref_error: RefErrorChoice = "warn",
     ) -> WeakCallback[None]:
@@ -723,7 +723,7 @@ class SignalInstance:
             caller = WeakSetitem(
                 obj,  # type: ignore
                 key,
-                max_args=maxargs,
+                max_args=cast("int | None", maxargs),
                 finalize=self._try_discard,
                 on_ref_error=on_ref_error,
             )

--- a/tests/test_bench.py
+++ b/tests/test_bench.py
@@ -86,9 +86,11 @@ def test_connect_time(
     if callback_type == "setattr":
         func: Callable = emitter.one_int.connect_setattr
         args: tuple = (obj, "x")
+        kwargs = {"maxargs": 1}
     elif callback_type == "setitem":
         func = emitter.one_int.connect_setitem
         args = (obj, "x")
+        kwargs = {"maxargs": 1}
     else:
         func = emitter.one_int.connect
         args = (_get_callback(callback_type, obj),)
@@ -107,10 +109,10 @@ def test_emit_time(benchmark: Callable, n_connections: int, callback_type: str) 
     obj = Obj()
     if callback_type == "setattr":
         for _ in range(n_connections):
-            emitter.one_int.connect_setattr(obj, "x")
+            emitter.one_int.connect_setattr(obj, "x", maxargs=1)
     elif callback_type == "setitem":
         for _ in range(n_connections):
-            emitter.one_int.connect_setitem(obj, "x")
+            emitter.one_int.connect_setitem(obj, "x", maxargs=1)
     else:
         callback = _get_callback(callback_type, obj)
         for _ in range(n_connections):

--- a/tests/test_psygnal.py
+++ b/tests/test_psygnal.py
@@ -256,9 +256,11 @@ def test_slot_types(type_: str) -> None:
     obj = MyObj()
 
     if type_ == "setattr":
-        signal.connect_setattr(obj, "x")
+        with pytest.warns(FutureWarning, match="The default value of maxargs"):
+            signal.connect_setattr(obj, "x")
     elif type_ == "setitem":
-        signal.connect_setitem(obj, "x")
+        with pytest.warns(FutureWarning, match="The default value of maxargs"):
+            signal.connect_setitem(obj, "x")
     elif type_ == "function":
         signal.connect(f_int)
 
@@ -717,9 +719,11 @@ def test_property_connect():
 
     a = A()
     emitter = Emitter()
-    emitter.one_int.connect_setattr(a, "x")
+
+    emitter.one_int.connect_setattr(a, "x", maxargs=1)
     assert len(emitter.one_int) == 1
-    emitter.two_int.connect_setattr(a, "x")
+    with pytest.warns(FutureWarning, match="The default value of maxargs"):
+        emitter.two_int.connect_setattr(a, "x")
     assert len(emitter.two_int) == 1
     emitter.one_int.emit(1)
     assert a.li == [1]
@@ -736,7 +740,7 @@ def test_property_connect():
     emitter.two_int.disconnect(s, missing_ok=False)
 
     with pytest.raises(AttributeError):
-        emitter.one_int.connect_setattr(a, "y")
+        emitter.one_int.connect_setattr(a, "y", maxargs=None)
 
 
 def test_connect_setitem():
@@ -752,7 +756,8 @@ def test_connect_setitem():
 
     t = T()
     my_obj = SupportsItem()
-    t.sig.connect_setitem(my_obj, "x")
+    with pytest.warns(FutureWarning, match="The default value of maxargs"):
+        t.sig.connect_setitem(my_obj, "x")
     t.sig.emit(5)
     assert my_obj._dict == {"x": 5}
     t.sig.disconnect_setitem(my_obj, "x")
@@ -761,7 +766,7 @@ def test_connect_setitem():
 
     obj = object()
     with pytest.raises(TypeError, match="does not support __setitem__"):
-        t.sig.connect_setitem(obj, "x")
+        t.sig.connect_setitem(obj, "x", maxargs=1)
 
     with pytest.raises(TypeError):
         t.sig.disconnect_setitem(obj, "x", missing_ok=False)


### PR DESCRIPTION
See #257 for some discussion, the default behavior of `connect_setattr` and `connect_setitem` is going to change in v0.11:

Both of these methods are really designed/intended for callbacks that expect a single value, but the current behavior, when dealing with a signal that emits two values, is to combine those two values into a tuple.  Meaning if the signal changes from a single argument to 2 arguments (as happened in #257), then the value received by the callback changes from a singleton type to a tuple.   This makes it much harder to change the emission signatures in a non-breaking way, which is *otherwise* designed to be rather easy to do (since it's ok to connect a signal to a callback that takes less arguments than the signal emits). 

This PR adds a `FutureWarning` to `connect_setattr` and `connect_setitem` if the `maxargs` argument is not passed at all, explaining the future change – which will go from a default of `None` in v0.10 to `1` in v0.11 (where `1` means that the callback will always only receive the first argument, and `None` is the current behavior of auto-up-conversion to a tuple).

