### PR TITLE
Name conflict in SignalGroup

### DIFF
--- a/src/psygnal/_evented_decorator.py
+++ b/src/psygnal/_evented_decorator.py
@@ -32,6 +32,7 @@ def evented(
     equality_operators: Optional[Dict[str, EqOperator]] = None,
     warn_on_no_fields: bool = ...,
     cache_on_instance: bool = ...,
+    signal_suffix: str = ...,
 ) -> T:
     ...
 
@@ -44,6 +45,7 @@ def evented(
     equality_operators: Optional[Dict[str, EqOperator]] = None,
     warn_on_no_fields: bool = ...,
     cache_on_instance: bool = ...,
+    signal_suffix: str = ...,
 ) -> Callable[[T], T]:
     ...
 
@@ -55,6 +57,7 @@ def evented(
     equality_operators: Optional[Dict[str, EqOperator]] = None,
     warn_on_no_fields: bool = True,
     cache_on_instance: bool = True,
+    signal_suffix: str = "",
 ) -> Union[Callable[[T], T], T]:
     """A decorator to add events to a dataclass.
 
@@ -94,6 +97,11 @@ def evented(
         access, but means that the owner instance will no longer be pickleable.  If
         `False`, the SignalGroup instance will *still* be cached, but not on the
         instance itself.
+    signal_suffix : str, optional
+        a suffix to append to the field names in `self.events` namespace.
+        For instance, if `signal_suffix="_changed"`, the signal for the field `field`
+        is accessed with `self.events.field_changed`, instead of the default
+        `self.events.field`.
 
     Returns
     -------
@@ -128,6 +136,7 @@ def evented(
             equality_operators=equality_operators,
             warn_on_no_fields=warn_on_no_fields,
             cache_on_instance=cache_on_instance,
+            signal_suffix=signal_suffix,
         )
         # as a decorator, this will have already been called
         descriptor.__set_name__(cls, events_namespace)

--- a/src/psygnal/_evented_decorator.py
+++ b/src/psygnal/_evented_decorator.py
@@ -57,7 +57,6 @@ def evented(
     equality_operators: Optional[Dict[str, EqOperator]] = None,
     warn_on_no_fields: bool = True,
     cache_on_instance: bool = True,
-    alias_private_fields: Optional[bool] = None,
     signal_suffix: str = "",
 ) -> Union[Callable[[T], T], T]:
     """A decorator to add events to a dataclass.
@@ -98,14 +97,6 @@ def evented(
         access, but means that the owner instance will no longer be pickleable.  If
         `False`, the SignalGroup instance will *still* be cached, but not on the
         instance itself.
-    alias_private_fields : Optional[bool], optional
-        If True, transform the private fields in aliases without the leading "_" to
-        create the signal names. These signals will be emitted by a change in the
-        aliased attribute name.
-        If False, skip private fields altogether, do not create signals associated with
-        them.
-        If None, the private fields name are passed as-is.
-        Default to None
     signal_suffix : str, optional
         a suffix to append to the field names in `self.events` namespace.
         For instance, if `signal_suffix="_changed"`, the signal for the field `field`
@@ -145,7 +136,6 @@ def evented(
             equality_operators=equality_operators,
             warn_on_no_fields=warn_on_no_fields,
             cache_on_instance=cache_on_instance,
-            alias_private_fields=alias_private_fields,
             signal_suffix=signal_suffix,
         )
         # as a decorator, this will have already been called

--- a/src/psygnal/_evented_decorator.py
+++ b/src/psygnal/_evented_decorator.py
@@ -57,6 +57,7 @@ def evented(
     equality_operators: Optional[Dict[str, EqOperator]] = None,
     warn_on_no_fields: bool = True,
     cache_on_instance: bool = True,
+    alias_private_fields: bool | None = None,
     signal_suffix: str = "",
 ) -> Union[Callable[[T], T], T]:
     """A decorator to add events to a dataclass.
@@ -97,6 +98,14 @@ def evented(
         access, but means that the owner instance will no longer be pickleable.  If
         `False`, the SignalGroup instance will *still* be cached, but not on the
         instance itself.
+    alias_private_fields : bool | None, optional
+        If True, transform the private fields in aliases without the leading "_" to
+        create the signal names. These signals will be emitted by a change in the
+        aliased attribute name.
+        If False, skip private fields altogether, do not create signals associated with
+        them.
+        If None, the private fields name are passed as-is.
+        Default to None
     signal_suffix : str, optional
         a suffix to append to the field names in `self.events` namespace.
         For instance, if `signal_suffix="_changed"`, the signal for the field `field`
@@ -136,6 +145,7 @@ def evented(
             equality_operators=equality_operators,
             warn_on_no_fields=warn_on_no_fields,
             cache_on_instance=cache_on_instance,
+            alias_private_fields=alias_private_fields,
             signal_suffix=signal_suffix,
         )
         # as a decorator, this will have already been called

--- a/src/psygnal/_evented_decorator.py
+++ b/src/psygnal/_evented_decorator.py
@@ -32,7 +32,6 @@ def evented(
     equality_operators: Optional[Dict[str, EqOperator]] = None,
     warn_on_no_fields: bool = ...,
     cache_on_instance: bool = ...,
-    alias_private_fields: Optional[bool] = ...,
     signal_suffix: str = ...,
 ) -> T:
     ...
@@ -46,7 +45,6 @@ def evented(
     equality_operators: Optional[Dict[str, EqOperator]] = None,
     warn_on_no_fields: bool = ...,
     cache_on_instance: bool = ...,
-    alias_private_fields: Optional[bool] = ...,
     signal_suffix: str = ...,
 ) -> Callable[[T], T]:
     ...

--- a/src/psygnal/_evented_decorator.py
+++ b/src/psygnal/_evented_decorator.py
@@ -57,7 +57,7 @@ def evented(
     equality_operators: Optional[Dict[str, EqOperator]] = None,
     warn_on_no_fields: bool = True,
     cache_on_instance: bool = True,
-    alias_private_fields: bool | None = None,
+    alias_private_fields: Optional[bool] = None,
     signal_suffix: str = "",
 ) -> Union[Callable[[T], T], T]:
     """A decorator to add events to a dataclass.
@@ -98,7 +98,7 @@ def evented(
         access, but means that the owner instance will no longer be pickleable.  If
         `False`, the SignalGroup instance will *still* be cached, but not on the
         instance itself.
-    alias_private_fields : bool | None, optional
+    alias_private_fields : Optional[bool], optional
         If True, transform the private fields in aliases without the leading "_" to
         create the signal names. These signals will be emitted by a change in the
         aliased attribute name.

--- a/src/psygnal/_evented_decorator.py
+++ b/src/psygnal/_evented_decorator.py
@@ -32,6 +32,7 @@ def evented(
     equality_operators: Optional[Dict[str, EqOperator]] = None,
     warn_on_no_fields: bool = ...,
     cache_on_instance: bool = ...,
+    alias_private_fields: Optional[bool] = ...,
     signal_suffix: str = ...,
 ) -> T:
     ...
@@ -45,6 +46,7 @@ def evented(
     equality_operators: Optional[Dict[str, EqOperator]] = None,
     warn_on_no_fields: bool = ...,
     cache_on_instance: bool = ...,
+    alias_private_fields: Optional[bool] = ...,
     signal_suffix: str = ...,
 ) -> Callable[[T], T]:
     ...

--- a/src/psygnal/_group.py
+++ b/src/psygnal/_group.py
@@ -122,7 +122,9 @@ class SignalGroup(SignalInstance):
     @property
     def signals(self) -> dict[str, SignalInstance]:
         """Return {name -> SignalInstance} map of all signal instances in this group."""
-        return {n: getattr(self, n) for n in type(self)._signals_}
+        sigs = {n: getattr(self, n) for n in type(self)._signals_}
+        # Make sure we grab SignalInstance's and not attributes with name conflict
+        return {n: sig for n, sig in sigs.items() if isinstance(sig, SignalInstance)}
 
     @classmethod
     def is_uniform(cls) -> bool:

--- a/src/psygnal/_group_descriptor.py
+++ b/src/psygnal/_group_descriptor.py
@@ -314,8 +314,8 @@ def evented_setattr(
 
             sig_name = f"{name}{signal_suffix}"
             group: SignalGroup | None = getattr(self, signal_group_name, None)
-            signal: SignalInstance | None = (
-                None if group is None else group.signals.get(sig_name, None)
+            signal: SignalInstance | None = getattr(group, "signals", {}).get(
+                sig_name, None
             )
             # don't emit if the signal doesn't exist or has no listeners
             if group is None or signal is None or len(signal) < 2 and not len(group):

--- a/src/psygnal/_group_descriptor.py
+++ b/src/psygnal/_group_descriptor.py
@@ -142,7 +142,7 @@ class _DataclassFieldSignalInstance(SignalInstance):
 def _build_dataclass_signal_group(
     cls: type,
     equality_operators: Iterable[tuple[str, EqOperator]] | None = None,
-    alias_private_fields: bool | None = None,
+    alias_private_fields: bool | dict | None = None,
     signal_suffix: str = "",
 ) -> type[SignalGroup]:
     """Build a SignalGroup with events for each field in a dataclass.
@@ -436,7 +436,7 @@ class SignalGroupDescriptor:
         warn_on_no_fields: bool = True,
         cache_on_instance: bool = True,
         patch_setattr: bool = True,
-        alias_private_fields: bool | None = False,
+        alias_private_fields: bool | dict = False,
         signal_suffix: str = "",
     ):
         self._signal_group = signal_group_class

--- a/src/psygnal/_group_descriptor.py
+++ b/src/psygnal/_group_descriptor.py
@@ -280,7 +280,7 @@ def evented_setattr(
 
             sig_name = f"{name}{signal_suffix}"
             group: SignalGroup | None = getattr(self, signal_group_name, None)
-            signal: SignalInstance | None = getattr(group, sig_name, None)
+            signal: SignalInstance | None = group.signals.get(sig_name, None)
             # don't emit if the signal doesn't exist or has no listeners
             if group is None or signal is None or len(signal) < 2 and not len(group):
                 return super_setattr(self, name, value)

--- a/src/psygnal/_group_descriptor.py
+++ b/src/psygnal/_group_descriptor.py
@@ -178,7 +178,7 @@ def _build_dataclass_signal_group(
         # Convert and validate private fields
         if alias_private_fields is not None and name.startswith("_"):
             if alias_private_fields:
-                name = name.removeprefix("_")
+                name = name.lstrip("_")
             else:
                 continue
 

--- a/src/psygnal/_group_descriptor.py
+++ b/src/psygnal/_group_descriptor.py
@@ -261,6 +261,11 @@ def evented_setattr(
         default "_psygnal_group_".
     super_setattr: Callable
         The original __setattr__ method for the class.
+    signal_suffix : str, optional
+        a suffix to append to the field names to find the signal in the SignalGroup
+        attributes. For instance, if the group is called "events" and
+        `signal_suffix="_changed"`, the signal for the field `field` that is emitted is
+        `self.events.field_changed`, instead of the default `self.events.field`.
     """
 
     def _inner(super_setattr: SetAttr) -> SetAttr:

--- a/src/psygnal/_group_descriptor.py
+++ b/src/psygnal/_group_descriptor.py
@@ -314,8 +314,8 @@ def evented_setattr(
 
             sig_name = f"{name}{signal_suffix}"
             group: SignalGroup | None = getattr(self, signal_group_name, None)
-            signal: SignalInstance | None = (
-                getattr(group, "signals", {}).get(sig_name, None)
+            signal: SignalInstance | None = getattr(group, "signals", {}).get(
+                sig_name, None
             )
             # don't emit if the signal doesn't exist or has no listeners
             if group is None or signal is None or len(signal) < 2 and not len(group):

--- a/src/psygnal/_group_descriptor.py
+++ b/src/psygnal/_group_descriptor.py
@@ -142,7 +142,7 @@ class _DataclassFieldSignalInstance(SignalInstance):
 def _build_dataclass_signal_group(
     cls: type,
     equality_operators: Iterable[tuple[str, EqOperator]] | None = None,
-    alias_private_fields: bool | dict | None = None,
+    alias_private_fields: bool | None = None,
     signal_suffix: str = "",
 ) -> type[SignalGroup]:
     """Build a SignalGroup with events for each field in a dataclass.
@@ -434,7 +434,7 @@ class SignalGroupDescriptor:
         warn_on_no_fields: bool = True,
         cache_on_instance: bool = True,
         patch_setattr: bool = True,
-        alias_private_fields: bool | dict = False,
+        alias_private_fields: bool | None = False,
         signal_suffix: str = "",
     ):
         self._signal_group = signal_group_class

--- a/src/psygnal/_group_descriptor.py
+++ b/src/psygnal/_group_descriptor.py
@@ -314,7 +314,9 @@ def evented_setattr(
 
             sig_name = f"{name}{signal_suffix}"
             group: SignalGroup | None = getattr(self, signal_group_name, None)
-            signal: SignalInstance | None = group.signals.get(sig_name, None)
+            signal: SignalInstance | None = (
+                None if group is None else group.signals.get(sig_name, None)
+            )
             # don't emit if the signal doesn't exist or has no listeners
             if group is None or signal is None or len(signal) < 2 and not len(group):
                 return super_setattr(self, name, value)

--- a/src/psygnal/_group_descriptor.py
+++ b/src/psygnal/_group_descriptor.py
@@ -142,46 +142,14 @@ class _DataclassFieldSignalInstance(SignalInstance):
 def _build_dataclass_signal_group(
     cls: type,
     equality_operators: Iterable[tuple[str, EqOperator]] | None = None,
-    alias_private_fields: bool | dict | None = None,
     signal_suffix: str = "",
 ) -> type[SignalGroup]:
-    """Build a SignalGroup with events for each field in a dataclass.
-
-    Parameters
-    ----------
-    cls : type
-        the dataclass to look for the fields to connect with signals.
-    equality_operators: Iterable[tuple[str, EqOperator]] | None
-        If defined, a mapping of field name and equality operator to use to compare if
-        each field was modified after being set.
-        Default to None
-    alias_private_fields : bool | None, optional
-        If True, transform the private fields in aliases without the leading "_" to
-        create the signal names. These signals will be emitted by a change in the
-        aliased attribute name.
-        If False, skip private fields altogether, do not create signals associated with
-        them.
-        If None, the private fields name are passed as-is.
-        Default to None
-    signal_suffix : str, optional
-        a suffix to append to the field names to find the signal in the SignalGroup
-        attributes. For instance, if the group is called "events" and
-        `signal_suffix="_changed"`, the signal for the field `field` that is emitted is
-        `self.events.field_changed`, instead of the default `self.events.field`.
-
-    """
+    """Build a SignalGroup with events for each field in a dataclass."""
     _equality_operators = dict(equality_operators) if equality_operators else {}
     signals = {}
     eq_map = _get_eq_operator_map(cls)
     # create a Signal for each field in the dataclass
     for name, type_ in iter_fields(cls):
-        # Convert and validate private fields
-        if alias_private_fields is not None and name.startswith("_"):
-            if alias_private_fields:
-                name = name.lstrip("_")
-            else:
-                continue
-
         # Equality operator
         if name in _equality_operators:
             if not callable(_equality_operators[name]):  # pragma: no cover
@@ -189,7 +157,6 @@ def _build_dataclass_signal_group(
             eq_map[name] = _equality_operators[name]
         else:
             eq_map[name] = _pick_equality_operator(type_)
-
         sig_name = f"{name}{signal_suffix}"
         field_type = object if type_ is None else type_
         signals[sig_name] = sig = Signal(field_type, field_type)
@@ -395,14 +362,6 @@ class SignalGroupDescriptor:
         events when fields change.  If `False`, no `__setattr__` method will be
         created.  (This will prevent signal emission, and assumes you are using a
         different mechanism to emit signals when fields change.)
-    alias_private_fields : bool | None, optional
-        If True, transform the private fields in aliases without the leading "_" to
-        create the signal names. These signals will be emitted by a change in the
-        aliased attribute name.
-        If False, skip private fields altogether, do not create signals associated with
-        them.
-        If None, the private fields name are passed as-is.
-        Default to None
     signal_suffix : str, optional
         a suffix to append to the field names in `self.events` namespace.
         For instance, if `signal_suffix="_changed"`, the signal for the field `field`
@@ -436,7 +395,6 @@ class SignalGroupDescriptor:
         warn_on_no_fields: bool = True,
         cache_on_instance: bool = True,
         patch_setattr: bool = True,
-        alias_private_fields: bool | dict = False,
         signal_suffix: str = "",
     ):
         self._signal_group = signal_group_class
@@ -445,7 +403,6 @@ class SignalGroupDescriptor:
         self._warn_on_no_fields = warn_on_no_fields
         self._cache_on_instance = cache_on_instance
         self._patch_setattr = patch_setattr
-        self._alias_private_fields = alias_private_fields
         self._signal_suffix = signal_suffix
 
     def __set_name__(self, owner: type, name: str) -> None:
@@ -519,10 +476,7 @@ class SignalGroupDescriptor:
 
     def _create_group(self, owner: type) -> type[SignalGroup]:
         Group = self._signal_group or _build_dataclass_signal_group(
-            owner,
-            equality_operators=self._eqop,
-            alias_private_fields=self._alias_private_fields,
-            signal_suffix=self._signal_suffix,
+            owner, self._eqop, self._signal_suffix
         )
         if self._warn_on_no_fields and not Group._signals_:
             warnings.warn(

--- a/src/psygnal/_group_descriptor.py
+++ b/src/psygnal/_group_descriptor.py
@@ -140,7 +140,9 @@ class _DataclassFieldSignalInstance(SignalInstance):
 
 @lru_cache(maxsize=None)
 def _build_dataclass_signal_group(
-    cls: type, equality_operators: Iterable[tuple[str, EqOperator]] | None = None, signal_suffix: str = ""
+    cls: type,
+    equality_operators: Iterable[tuple[str, EqOperator]] | None = None,
+    signal_suffix: str = "",
 ) -> type[SignalGroup]:
     """Build a SignalGroup with events for each field in a dataclass."""
     _equality_operators = dict(equality_operators) if equality_operators else {}
@@ -220,13 +222,17 @@ def evented_setattr(
 
 @overload
 def evented_setattr(
-    signal_group_name: str, super_setattr: Literal[None] | None = None, signal_suffix: str = ""
+    signal_group_name: str,
+    super_setattr: Literal[None] | None = None,
+    signal_suffix: str = "",
 ) -> Callable[[SetAttr], SetAttr]:
     ...
 
 
 def evented_setattr(
-    signal_group_name: str, super_setattr: SetAttr | None = None, signal_suffix: str = ""
+    signal_group_name: str,
+    super_setattr: SetAttr | None = None,
+    signal_suffix: str = "",
 ) -> SetAttr | Callable[[SetAttr], SetAttr]:
     """Create a new __setattr__ method that emits events when fields change.
 
@@ -461,7 +467,9 @@ class SignalGroupDescriptor:
         return self._instance_map[obj_id]
 
     def _create_group(self, owner: type) -> type[SignalGroup]:
-        Group = self._signal_group or _build_dataclass_signal_group(owner, self._eqop, self._signal_suffix)
+        Group = self._signal_group or _build_dataclass_signal_group(
+            owner, self._eqop, self._signal_suffix
+        )
         if self._warn_on_no_fields and not Group._signals_:
             warnings.warn(
                 f"No mutable fields found on class {owner}: no events will be "

--- a/src/psygnal/_group_descriptor.py
+++ b/src/psygnal/_group_descriptor.py
@@ -315,7 +315,7 @@ def evented_setattr(
             sig_name = f"{name}{signal_suffix}"
             group: SignalGroup | None = getattr(self, signal_group_name, None)
             signal: SignalInstance | None = (
-                None if group is None else group.signals.get(sig_name, None)
+                getattr(group, "signals", {}).get(sig_name, None)
             )
             # don't emit if the signal doesn't exist or has no listeners
             if group is None or signal is None or len(signal) < 2 and not len(group):

--- a/src/psygnal/_group_descriptor.py
+++ b/src/psygnal/_group_descriptor.py
@@ -314,8 +314,8 @@ def evented_setattr(
 
             sig_name = f"{name}{signal_suffix}"
             group: SignalGroup | None = getattr(self, signal_group_name, None)
-            signal: SignalInstance | None = getattr(group, "signals", {}).get(
-                sig_name, None
+            signal: SignalInstance | None = (
+                None if group is None else group.signals.get(sig_name, None)
             )
             # don't emit if the signal doesn't exist or has no listeners
             if group is None or signal is None or len(signal) < 2 and not len(group):


### PR DESCRIPTION
* psygnal version: 0.9.5
* Python version: 3.11

### Description

I created an Evented Dataclass with private field names in conflict with the attributes of the `SignalInstance` class.
This resulted in an AttributeError. The bug comes from a name conflicts inside `SignalGroup`.

I tried an easy solution to avoid name conflict, by allowing to set a suffix for the signal names.

### What I Did

```python
from typing import ClassVar
from attrs import define, field
from psygnal import SignalGroupDescriptor, Signal, SignalGroup

# Evented Dataclass error
@define
class Test:
    events: ClassVar[SignalGroupDescriptor] = SignalGroupDescriptor()

    _name: str = field(default="name")
#    _args_queue: int = field(default=1)
#    _instance: int = field(default=1)
    age: int = field(default=1)

m = Test()
m.events  # -> AttributeError: 'str' object has no attribute 'connect'

# SignalGroup error
class Events(SignalGroup):
    sig1 = Signal(int)
    _name = Signal(int)

events = Events()  # ->  AttributeError: 'str' object has no attribute 'connect'

# With this PR
@define
class Test:
    events: ClassVar[SignalGroupDescriptor] = SignalGroupDescriptor(signal_suffix="_changed")

    _name: str = field(default="name")
    _args_queue: int = field(default=1)
    _instance: int = field(default=1)
    age: int = field(default=1)

m = Test()
@m.events.connect
def on_any_change(info: EmissionInfo):
    field_name = info.signal.name.removesuffix("_changed")
    print(f"signal {info.signal.name!r} emitted because the field {field_name!r} changed: {info.args}")

m._name = "new" 
# >> signal '_name_changed' emitted because the field '_name' changed: ('new', 'name')'_name_changed' changed to ('new', 'name')

```
