### PR TITLE
feat: signal alias in field metadata

### DIFF
--- a/src/psygnal/__init__.py
+++ b/src/psygnal/__init__.py
@@ -29,6 +29,7 @@ __all__ = [
     "EventedModel",
     "get_evented_namespace",
     "is_evented",
+    "PSYGNAL_METADATA",
     "Signal",
     "SignalGroup",
     "SignalGroupDescriptor",
@@ -48,6 +49,7 @@ if os.getenv("PSYGNAL_UNCOMPILED"):
         stacklevel=2,
     )
 
+from ._dataclass_utils import PSYGNAL_METADATA
 from ._evented_decorator import evented
 from ._exceptions import EmitLoopError
 from ._group import EmissionInfo, SignalGroup

--- a/src/psygnal/_evented_decorator.py
+++ b/src/psygnal/_evented_decorator.py
@@ -5,7 +5,10 @@ from typing import TYPE_CHECKING, Callable, Literal, Mapping, TypeVar, overload
 from psygnal._group_descriptor import SignalGroupDescriptor
 
 if TYPE_CHECKING:
-    from psygnal._group_descriptor import EqOperator, FieldAliasFunc
+    from psygnal._group_descriptor import (  # type: ignore[attr-defined]
+        EqOperator,
+        FieldAliasFunc,
+    )
 
 __all__ = ["evented"]
 

--- a/src/psygnal/_group_descriptor.py
+++ b/src/psygnal/_group_descriptor.py
@@ -21,7 +21,7 @@ from typing import (
     overload,
 )
 
-from ._dataclass_utils import iter_fields
+from ._dataclass_utils import iter_fields_with_options
 from ._group import SignalGroup
 from ._signal import Signal, SignalInstance
 
@@ -31,7 +31,8 @@ if TYPE_CHECKING:
 
     from psygnal._weak_callback import RefErrorChoice, WeakCallback
 
-    EqOperator: TypeAlias = Callable[[Any, Any], bool]
+    from ._dataclass_utils import EqOperator
+
     FieldAliasFunc: TypeAlias = Callable[[str], Optional[str]]
 
 __all__ = ["is_evented", "get_evented_namespace", "SignalGroupDescriptor"]
@@ -196,28 +197,43 @@ def _build_dataclass_signal_group(
 
     signals = {}
     # create a Signal for each field in the dataclass
-    for name, type_ in iter_fields(cls):
-        if name in _equality_operators:
-            if not callable(_equality_operators[name]):  # pragma: no cover
+    for f in iter_fields_with_options(cls):
+        # skip this field
+        if f.skip:
+            continue
+
+        # Equality operator
+        if f.eq is not None:
+            if not callable(f.eq):  # pragma: no cover
+                raise TypeError("`eq` field metadata must be callable")
+            eq_map[f.name] = f.eq
+        elif f.name in _equality_operators:
+            if not callable(_equality_operators[f.name]):  # pragma: no cover
                 raise TypeError("EqOperator must be callable")
-            eq_map[name] = _equality_operators[name]
+            eq_map[f.name] = _equality_operators[f.name]
         else:
-            eq_map[name] = _pick_equality_operator(type_)
+            eq_map[f.name] = _pick_equality_operator(f.type_)
 
         # Resolve the signal name for the field
         sig_name: str | None
-        if name in _signal_aliases:  # an alias has been provided in a mapping
-            sig_name = _signal_aliases[name]
+        if f.alias is not None:  # an alias has been provided in the field metadata
+            _signal_aliases[f.name] = sig_name = f.alias
+        elif f.name in _signal_aliases:  # an alias has been provided in a mapping
+            sig_name = _signal_aliases[f.name]
         elif callable(transform):  # a callable has been provided
-            _signal_aliases[name] = sig_name = transform(name)
-        elif name in signal_group_sig_aliases:  # an alias has been defined in the class
-            _signal_aliases[name] = sig_name = signal_group_sig_aliases[name]
+            _signal_aliases[f.name] = sig_name = transform(f.name)
+        elif f.name in signal_group_sig_aliases:  # an alias was defined in the class
+            _signal_aliases[f.name] = sig_name = signal_group_sig_aliases[f.name]
         else:  # no alias has been defined, use the field name as the signal name
-            sig_name = name
+            sig_name = f.name
 
         # An alias mapping or callable returned `None`, skip this field
         if sig_name is None:
             continue
+
+        # Create the signal, but the alias is set to None
+        if f.disable_setattr:
+            _signal_aliases[f.name] = None
 
         # Repeated signal
         if sig_name in signals:
@@ -239,7 +255,7 @@ def _build_dataclass_signal_group(
             continue
 
         # Create the Signal
-        field_type = object if type_ is None else type_
+        field_type = object if f.type_ is None else f.type_
         signals[sig_name] = sig = Signal(field_type, field_type)
         # patch in our custom SignalInstance class with maxargs=1 on connect_setattr
         sig._signal_instance_class = _DataclassFieldSignalInstance

--- a/tests/test_custom_fields.py
+++ b/tests/test_custom_fields.py
@@ -1,0 +1,197 @@
+# from __future__ import annotations  # breaks msgspec Annotated
+
+import contextlib
+import sys
+from typing import ClassVar, Dict, Optional
+from unittest.mock import Mock
+
+import pytest
+
+from psygnal import (
+    PSYGNAL_METADATA,
+    EmissionInfo,
+    SignalGroupDescriptor,
+    is_evented,
+)
+
+Annotated = None
+with contextlib.suppress(ImportError):
+    from typing import Annotated  # type: ignore
+
+
+min_py_version = pytest.mark.skipif(
+    sys.version_info < (3, 9), reason="needs typing.Annotated"
+)
+
+
+def get_signal_aliases(obj: object) -> Dict[str, Optional[str]]:
+    if not is_evented(obj):
+        return {}
+    return obj.events._psygnal_aliases
+
+
+@pytest.mark.parametrize(
+    "type_",
+    [
+        "dataclass",
+        "attrs",
+        pytest.param("pydantic", marks=min_py_version),
+        pytest.param("msgspec", marks=min_py_version),
+    ],
+)
+def test_field_metadata(type_: str) -> None:
+    a_metadata = {PSYGNAL_METADATA: {"alias": "a_changed"}}
+    b_metadata = {PSYGNAL_METADATA: {"eq": lambda s1, s2: s1.lower() == s2.lower()}}
+    c_metadata = {PSYGNAL_METADATA: {"skip": True}}
+    d_metadata = {PSYGNAL_METADATA: {"disable_setattr": True}}
+
+    if type_ == "dataclass":
+        from dataclasses import dataclass, field
+
+        @dataclass
+        class Base:
+            a: int = field(metadata=a_metadata)
+            events: ClassVar = SignalGroupDescriptor()
+
+        @dataclass
+        class Foo(Base):
+            b: str = field(metadata=b_metadata)
+
+        @dataclass
+        class Bar(Foo):
+            c: float = field(metadata=c_metadata)
+
+        @dataclass
+        class Baz(Bar):
+            d: float = field(metadata=d_metadata)
+
+    elif type_ == "attrs":
+        from attrs import define, field
+
+        @define
+        class Base:
+            a: int = field(metadata=a_metadata)
+            events: ClassVar = SignalGroupDescriptor()
+
+        @define
+        class Foo(Base):
+            b: str = field(metadata=b_metadata)
+
+        @define
+        class Bar(Foo):
+            c: float = field(metadata=c_metadata)
+
+        @define
+        class Baz(Bar):
+            d: float = field(metadata=d_metadata)
+
+    elif type_ == "pydantic":
+        pytest.importorskip("pydantic", minversion="2")
+        from pydantic import BaseModel, Field
+
+        class Base(BaseModel):
+            a: Annotated[int, a_metadata]
+            events: ClassVar = SignalGroupDescriptor()
+
+        # Alternative, using Field `json_schema_extra` keyword argument
+        class Foo(Base):
+            b: str = Field(json_schema_extra=b_metadata)
+
+        class Bar(Foo):
+            c: Annotated[float, c_metadata]
+
+        class Baz(Bar):
+            d: Annotated[float, d_metadata]
+
+    elif type_ == "msgspec":
+        msgspec = pytest.importorskip("msgspec")
+
+        class Base(msgspec.Struct):  # type: ignore
+            a: Annotated[int, msgspec.Meta(extra=a_metadata)]
+            events: ClassVar = SignalGroupDescriptor()
+
+        class Foo(Base):
+            b: Annotated[str, msgspec.Meta(extra=b_metadata)]
+
+        class Bar(Foo):
+            c: Annotated[float, msgspec.Meta(extra=c_metadata)]
+
+        class Baz(Bar):
+            d: Annotated[float, msgspec.Meta(extra=d_metadata)]
+
+    assert Bar.events is Base.events
+
+    # Instantiate objects
+    base = Base(a=1)
+    foo = Foo(a=1, b="b")
+    bar = Bar(a=1, b="b", c=3.0)
+    bar2 = Bar(a=1, b="b", c=3.0)
+    baz = Baz(a=1, b="b", c=3.0, d=4.0)
+
+    # the patching of __setattr__ should only happen once
+    # and it will happen only on the first access of .events
+    assert set(base.events) == {"a_changed"}
+    assert set(foo.events) == {"a_changed", "b"}
+    assert set(bar.events) == {"a_changed", "b"}
+    assert set(bar2.events) == {"a_changed", "b"}
+    assert set(baz.events) == {"a_changed", "b", "d"}
+
+    assert get_signal_aliases(base) == {"a": "a_changed"}
+    assert get_signal_aliases(foo) == {"a": "a_changed"}
+    assert get_signal_aliases(bar) == {"a": "a_changed"}
+    assert get_signal_aliases(bar2) == {"a": "a_changed"}
+    assert get_signal_aliases(baz) == {"a": "a_changed", "d": None}
+
+    mock = Mock()
+    assert not hasattr(foo.events, "a")
+    foo.events.a_changed.connect(mock)
+    foo.events.b.connect(mock)
+    baz.events.a_changed.connect(mock)
+    baz.events.b.connect(mock)
+    baz.events.d.connect(mock)
+
+    # base doesn't affect subclass
+    assert not hasattr(base.events, "a")
+    base.events.a_changed.emit(1)
+    mock.assert_not_called()
+
+    base.events.a_changed.emit(2)
+    mock.assert_not_called()
+
+    # `alias` works
+    assert hasattr(foo.events, "a_changed")
+    foo.a = 2
+    mock.assert_called_once_with(2, 1)
+    mock.reset_mock()
+
+    baz.a = 2
+    mock.assert_called_once_with(2, 1)
+    mock.reset_mock()
+
+    # `eq` works
+    foo.b = "B"
+    mock.assert_not_called()
+    baz.b = "B"
+    mock.assert_not_called()
+
+    foo.b = "C"
+    mock.assert_called_once_with("C", "B")
+    mock.reset_mock()
+
+    # `skip` works
+    assert not hasattr(baz.events, "c")
+
+    # `disable_setattr` works
+    baz.d = 5.0
+    mock.assert_not_called()
+
+    # Check all
+    mock1 = Mock()
+    baz.events.all.connect(mock1)
+    baz.c = 4.0
+    mock1.assert_not_called()
+    baz.d = 6.0
+    mock1.assert_not_called()
+    baz.a = 3
+    assert hasattr(baz.events, "a_changed")
+    mock1.assert_called_once_with(EmissionInfo(baz.events.a_changed, (3, 2)))


### PR DESCRIPTION
solves #261
supersedes #260 

Add a keyword argument to `SignalGroupDescriptor` to specify signal aliases (if the alias is None, no signal is emitted when changing the field). The signal aliases table is stored in the `SignalGroup` class.

Also allow for specifying per-field options for Signals using the metadata of the fields (different implementation in the different packages).

It solves #261 elegantly and makes subclassing more automatic:

```python
from typing import ClassVar
from attrs import define, field
from psygnal import SignalGroupDescriptor, EmissionInfo


@define
class Model:
    events: ClassVar = SignalGroupDescriptor(
        signal_suffix="_changed", 
        signal_aliases={"_controller": None, "_name": "name_changed", "name": None},
    )

    _controller: str = field()
    _name: str = field(kw_only=True)

    @property
    def name(self) -> str:
        return self._name

    @name.setter
    def name(self, value: str) -> None:
        # Generate a unique name among siblings
        siblings = [self.controller]
        value = f"{value}_1" if value in siblings else value
        self._name = value

    @property
    def controller(self) -> str:
        return self._controller

m = Model("ctt", name="c")
@m.events.connect
def on_any_change(info: EmissionInfo):
    print(f"signal {info.signal.name!r} emitted {info.args}")

m.name = "ctt"; m.name
# >> signal 'name_changed' emitted ('ctt_1', 'c')
```