### PR TITLE
build: remove all dependencies

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -86,7 +86,7 @@ jobs:
     uses: pyapp-kit/workflows/.github/workflows/test-dependents.yml@v1
     with:
       dependency-repo: pyapp-kit/magicgui
-      dependency-extras: "testing"
+      dependency-extras: "test"
       qt: "pyside2"
       python-version: "3.10"
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,19 +49,6 @@ jobs:
           - os: windows-latest
             python-version: "3.12"
 
-  test-min-reqs:
-    name: Test min reqs
-    uses: pyapp-kit/workflows/.github/workflows/test-pyrepo.yml@main
-    with:
-      os: ubuntu-latest
-      python-version: ${{ matrix.python-version }}
-      pip-install-min-reqs: true
-    secrets: inherit
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
-
   test-qt:
     name: Test Qt
     uses: pyapp-kit/workflows/.github/workflows/test-pyrepo.yml@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,6 +49,19 @@ jobs:
           - os: windows-latest
             python-version: "3.12"
 
+  test-min-reqs:
+    name: Test min reqs
+    uses: pyapp-kit/workflows/.github/workflows/test-pyrepo.yml@main
+    with:
+      os: ubuntu-latest
+      python-version: ${{ matrix.python-version }}
+      pip-install-min-reqs: true
+    secrets: inherit
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
+
   test-qt:
     name: Test Qt
     uses: pyapp-kit/workflows/.github/workflows/test-pyrepo.yml@v1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -45,3 +45,4 @@ repos:
         additional_dependencies:
           - types-attrs
           - pydantic
+          - typing_extensions

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 Psygnal (pronounced "signal") is a pure python implementation of the [observer
 pattern](https://en.wikipedia.org/wiki/Observer_pattern), with the API of
 [Qt-style Signals](https://doc.qt.io/qt-5/signalsandslots.html) with (optional)
-signature and type checking, and support for threading.
+signature and type checking, and support for threading.  It has no dependencies.
 
 > This library does ***not*** require or use Qt in any way, It simply implements
 > a similar observer pattern API.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,29 +24,25 @@ classifiers = [
     "Typing :: Typed",
 ]
 dynamic = ["version"]
-dependencies = ["typing-extensions >=3.7.4.2", "mypy_extensions"]
+dependencies = [
+    # typing-extensions is in the source code, but not actually required
+    # at runtime. All uses are guarded by if TYPE_CHECKING
+]
 
 # extras
 # https://peps.python.org/pep-0621/#dependencies-optional-dependencies
 [project.optional-dependencies]
 dev = [
     "black",
-    "cruft",
-    "dask",
     "ipython",
     "mypy",
-    "numpy",
+    "mypy_extensions",
     "pre-commit",
-    "pydantic",
     "PyQt5",
-    "pytest-cov",
     "pytest-mypy-plugins",
-    "pytest-qt",
-    "pytest",
-    "qtpy",
     "rich",
     "ruff",
-    "wrapt",
+    "typing-extensions",
 ]
 docs = [
     "griffe==0.25.5",
@@ -99,6 +95,7 @@ require-runtime-dependencies = true
 dependencies = [
     "hatch-mypyc>=0.13.0",
     "mypy>=0.991",
+    "mypy_extensions >=0.4.2",
     "pydantic",
     "types-attrs",
     "msgspec ; python_version >= '3.8'",

--- a/src/psygnal/_dataclass_utils.py
+++ b/src/psygnal/_dataclass_utils.py
@@ -4,15 +4,13 @@ import contextlib
 import dataclasses
 import sys
 import types
-from typing import TYPE_CHECKING, Any, Iterator, List, cast, overload
-
-from typing_extensions import Protocol
+from typing import TYPE_CHECKING, Any, Iterator, List, Protocol, cast, overload
 
 if TYPE_CHECKING:
     import attrs
     import msgspec
     from pydantic import BaseModel
-    from typing_extensions import TypeGuard
+    from typing_extensions import TypeGuard  # py310
 
 
 class _DataclassParams(Protocol):

--- a/src/psygnal/_evented_decorator.py
+++ b/src/psygnal/_evented_decorator.py
@@ -1,8 +1,8 @@
 from typing import (
-    TYPE_CHECKING,
     Any,
     Callable,
     Dict,
+    Literal,
     Optional,
     Type,
     TypeVar,
@@ -11,9 +11,6 @@ from typing import (
 )
 
 from psygnal._group_descriptor import SignalGroupDescriptor
-
-if TYPE_CHECKING:
-    from typing_extensions import Literal
 
 __all__ = ["evented"]
 

--- a/src/psygnal/_evented_model_v1.py
+++ b/src/psygnal/_evented_model_v1.py
@@ -25,7 +25,7 @@ if TYPE_CHECKING:
     import pydantic.v1.main as pydantic_main
     from pydantic.v1 import BaseModel, PrivateAttr, utils
     from pydantic.v1.fields import Field, FieldInfo, ModelField
-    from typing_extensions import dataclass_transform
+    from typing_extensions import dataclass_transform  # py311
 
     EqOperator = Callable[[Any, Any], bool]
 

--- a/src/psygnal/_evented_model_v2.py
+++ b/src/psygnal/_evented_model_v2.py
@@ -26,13 +26,13 @@ from ._signal import Signal, SignalInstance
 if TYPE_CHECKING:
     from inspect import Signature
 
-    from typing_extensions import dataclass_transform
+    from typing_extensions import dataclass_transform  # py311
 
     EqOperator = Callable[[Any, Any], bool]
 
 else:
     try:
-        from typing_extensions import dataclass_transform
+        from typing_extensions import dataclass_transform  # py311
     except ImportError:  # pragma: no cover
 
         def dataclass_transform(*args, **kwargs):

--- a/src/psygnal/_group.py
+++ b/src/psygnal/_group.py
@@ -22,9 +22,9 @@ from typing import (
     NamedTuple,
 )
 
-from mypy_extensions import mypyc_attr
-
 from psygnal._signal import Signal, SignalInstance, _SignalBlocker
+
+from ._mypyc import mypyc_attr
 
 __all__ = ["EmissionInfo", "SignalGroup"]
 

--- a/src/psygnal/_group_descriptor.py
+++ b/src/psygnal/_group_descriptor.py
@@ -12,6 +12,7 @@ from typing import (
     Callable,
     ClassVar,
     Iterable,
+    Literal,
     Type,
     TypeVar,
     cast,
@@ -24,7 +25,6 @@ from ._signal import Signal, SignalInstance
 
 if TYPE_CHECKING:
     from _weakref import ref as ref
-    from typing_extensions import Literal
 
     from psygnal._weak_callback import RefErrorChoice, WeakCallback
 

--- a/src/psygnal/_mypyc.py
+++ b/src/psygnal/_mypyc.py
@@ -1,0 +1,12 @@
+__all__ = ["mypyc_attr"]
+
+try:
+    # mypy_extensions is not required at runtime, it's only used by mypyc
+    # to provide type information to the mypyc compiler.
+    # we include it in the [tool.hatch.build.targets.wheel.hooks.mypyc]
+    # section of pyproject.toml so that it's available when building.
+    from mypy_extensions import mypyc_attr
+except ImportError:
+
+    def mypyc_attr(*_, **__):  # type: ignore
+        return lambda x: x

--- a/src/psygnal/_queue.py
+++ b/src/psygnal/_queue.py
@@ -2,12 +2,10 @@ from __future__ import annotations
 
 from queue import Queue
 from threading import Thread, current_thread, main_thread
-from typing import TYPE_CHECKING, Any, Callable, ClassVar, DefaultDict, Tuple
+from typing import TYPE_CHECKING, Any, Callable, ClassVar, DefaultDict, Literal, Tuple
 
 if TYPE_CHECKING:
     import collections
-
-    from typing_extensions import Literal
 
 
 from ._exceptions import EmitLoopError

--- a/src/psygnal/_signal.py
+++ b/src/psygnal/_signal.py
@@ -15,19 +15,20 @@ from typing import (
     ContextManager,
     Iterable,
     Iterator,
+    Literal,
     NoReturn,
     Type,
     TypeVar,
     Union,
     cast,
+    get_args,
+    get_origin,
     get_type_hints,
     overload,
 )
 
-from mypy_extensions import mypyc_attr
-from typing_extensions import get_args, get_origin
-
 from ._exceptions import EmitLoopError
+from ._mypyc import mypyc_attr
 from ._queue import QueuedCallback
 from ._weak_callback import (
     StrongFunction,
@@ -38,7 +39,6 @@ from ._weak_callback import (
 )
 
 if TYPE_CHECKING:
-    from typing_extensions import Literal
 
     from ._group import EmissionInfo
     from ._weak_callback import RefErrorChoice

--- a/src/psygnal/_throttler.py
+++ b/src/psygnal/_throttler.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 
 from threading import Timer
-from typing import TYPE_CHECKING, Any, Callable, Generic, TypeVar
+from typing import TYPE_CHECKING, Any, Callable, Generic, Literal, TypeVar
 
 if TYPE_CHECKING:
     import inspect
 
-    from typing_extensions import Literal, ParamSpec
+    from typing_extensions import ParamSpec  # py310
 
     Kind = Literal["throttler", "debouncer"]
     EmissionPolicy = Literal["trailing", "leading"]

--- a/src/psygnal/_throttler.pyi
+++ b/src/psygnal/_throttler.pyi
@@ -1,7 +1,7 @@
 # this pyi file exists until we can use ParamSpec with mypyc in the main file.
-from typing import Any, Callable, Generic, overload
+from typing import Any, Callable, Generic, Literal, overload
 
-from typing_extensions import Literal, ParamSpec
+from typing_extensions import ParamSpec  # py310
 
 P = ParamSpec("P")
 

--- a/src/psygnal/_weak_callback.py
+++ b/src/psygnal/_weak_callback.py
@@ -4,15 +4,23 @@ import sys
 import weakref
 from functools import partial
 from types import BuiltinMethodType, FunctionType, MethodType, MethodWrapperType
-from typing import TYPE_CHECKING, Any, Callable, Generic, TypeVar, cast
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Generic,
+    Literal,
+    Protocol,
+    TypeVar,
+    cast,
+)
 from warnings import warn
 
-from mypy_extensions import mypyc_attr
-from typing_extensions import Protocol
+from ._mypyc import mypyc_attr
 
 if TYPE_CHECKING:
     import toolz
-    from typing_extensions import Literal, TypeAlias, TypeGuard
+    from typing_extensions import TypeAlias, TypeGuard  # py310
 
     RefErrorChoice: TypeAlias = Literal["raise", "warn", "ignore"]
 

--- a/src/psygnal/containers/_evented_set.py
+++ b/src/psygnal/containers/_evented_set.py
@@ -1,14 +1,13 @@
 from __future__ import annotations
 
 from itertools import chain
-from typing import TYPE_CHECKING, Any, Iterable, Iterator, MutableSet, TypeVar
+from typing import TYPE_CHECKING, Any, Final, Iterable, Iterator, MutableSet, TypeVar
 
 from psygnal import Signal, SignalGroup
 
 if TYPE_CHECKING:
     from typing import Self
 
-    from typing_extensions import Final
 
 _T = TypeVar("_T")
 

--- a/tests/test_evented_model.py
+++ b/tests/test_evented_model.py
@@ -1,11 +1,10 @@
 import inspect
 import sys
-from typing import Any, ClassVar, List, Sequence, Union
+from typing import Any, ClassVar, List, Protocol, Sequence, Union, runtime_checkable
 from unittest.mock import Mock, call, patch
 
 import numpy as np
 import pytest
-from typing_extensions import Protocol, runtime_checkable
 
 try:
     from pydantic import PrivateAttr

--- a/tests/test_group.py
+++ b/tests/test_group.py
@@ -2,7 +2,11 @@ from copy import deepcopy
 from unittest.mock import Mock, call
 
 import pytest
-from typing_extensions import Annotated
+
+try:
+    from typing import Annotated  # py39
+except ImportError:
+    Annotated = None
 
 from psygnal import EmissionInfo, Signal, SignalGroup
 
@@ -50,6 +54,7 @@ def test_uniform_group():
     assert str(e.value).startswith("All Signals in a strict SignalGroup must")
 
 
+@pytest.mark.skipif(Annotated is None, reason="requires typing.Annotated")
 def test_nonhashable_args():
     """Test that non-hashable annotations are allowed in a SignalGroup"""
 

--- a/tests/test_psygnal.py
+++ b/tests/test_psygnal.py
@@ -3,12 +3,11 @@ import time
 from contextlib import suppress
 from functools import partial, wraps
 from inspect import Signature
-from typing import Optional
+from typing import Literal, Optional
 from unittest.mock import MagicMock, Mock, call
 
 import pytest
 import toolz
-from typing_extensions import Literal
 
 from psygnal import EmitLoopError, Signal, SignalInstance, _compiled
 from psygnal._weak_callback import WeakCallback

--- a/tests/test_qt_compat.py
+++ b/tests/test_qt_compat.py
@@ -1,11 +1,10 @@
 """qtbot should work for testing!"""
 
 from threading import Thread, current_thread, main_thread
-from typing import TYPE_CHECKING, Any, Callable, Tuple
+from typing import TYPE_CHECKING, Any, Callable, Literal, Tuple
 from unittest.mock import Mock
 
 import pytest
-from typing_extensions import Literal
 
 from psygnal import Signal
 from psygnal._signal import _guess_qtsignal_signature


### PR DESCRIPTION
This PR removes `mypy_extensions` and `typing-extensions` from the dependencies.  Neither are required at runtime.  all use of typing-extensions is guarded behind TYPE_CHECKING imports, and mypy_extensions is only required at build time (in fact, it's not even needed at all, it seems you can just put `from mypy_extensions import mypyc_attr` inside of a try/except and that is sufficient) but it's included at build time anyway

it also moves some of the older type hint imports from typing-extensions to typing