### PR TITLE
perf: Do not use reducer if there is no callback in `SingalInstance.resume`

### DIFF
--- a/src/psygnal/_signal.py
+++ b/src/psygnal/_signal.py
@@ -1113,6 +1113,10 @@ class SignalInstance:
         # EventedModel.update, it may be undefined (as seen in tests)
         if not getattr(self, "_args_queue", None):
             return
+        if len(self._slots) == 0:
+            self._args_queue = []
+            return
+
         if reducer is not None:
             if len(inspect.signature(reducer).parameters) == 1:
                 args = cast("ReducerOneArg", reducer)(self._args_queue)


### PR DESCRIPTION
This is followup to #277 

Remove the whole reducing operation if there is no callback. 

