### PR TITLE
feat: deduplicate events emision in nested properties

### DIFF
--- a/src/psygnal/_evented_model_utils.py
+++ b/src/psygnal/_evented_model_utils.py
@@ -8,13 +8,13 @@ if TYPE_CHECKING:
     import pydantic.version
 
     if pydantic.version.VERSION.startswith("2"):
-        from ._evented_model_v2 import EventedModel as EventedModelv1
+        from ._evented_model_v2 import EventedModel as EventedModelV1
     else:
-        from ._evented_model_v1 import EventedModel as EventedModelv2
+        from ._evented_model_v1 import EventedModel as EventedModelV2
 
 
 class ComparisonDelayer:
-    def __init__(self, target: EventedModelv1 | EventedModelv2) -> None:
+    def __init__(self, target: EventedModelV1 | EventedModelV2) -> None:
         self._target = target
 
     def __enter__(self) -> None:

--- a/src/psygnal/_evented_model_utils.py
+++ b/src/psygnal/_evented_model_utils.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from types import TracebackType
+
+    import pydantic.version
+
+    if pydantic.version.VERSION.startswith("2"):
+        from ._evented_model_v2 import EventedModel as EventedModelv1
+    else:
+        from ._evented_model_v1 import EventedModel as EventedModelv2
+
+
+class ComparisonDelayer:
+    def __init__(self, target: EventedModelv1 | EventedModelv2) -> None:
+        self._target = target
+
+    def __enter__(self) -> None:
+        self._target._delay_check_semaphore += 1
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> None:
+        self._target._delay_check_semaphore -= 1
+        self._target._check_if_values_changed_and_emit_if_needed()

--- a/src/psygnal/_evented_model_v1.py
+++ b/src/psygnal/_evented_model_v1.py
@@ -1,7 +1,6 @@
 import sys
 import warnings
 from contextlib import contextmanager
-from types import TracebackType
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -9,7 +8,6 @@ from typing import (
     ClassVar,
     Dict,
     Iterator,
-    Optional,
     Set,
     Type,
     Union,
@@ -17,7 +15,7 @@ from typing import (
     no_type_check,
 )
 
-# from ._evented_model_utils import ComparisonDelayer
+from ._evented_model_utils import ComparisonDelayer
 from ._group import SignalGroup
 from ._group_descriptor import _check_field_equality, _pick_equality_operator
 from ._signal import Signal, SignalInstance
@@ -159,6 +157,10 @@ class EventedMetaclass(pydantic_main.ModelMetaclass):
 
         cls.__field_dependents__ = _get_field_dependents(cls)
         cls.__signal_group__ = type(f"{name}SignalGroup", (SignalGroup,), signals)
+        if not cls.__field_dependents__ and hasattr(cls, "_setattr_no_dependants"):
+            cls._setattr_default = cls._setattr_no_dependants
+        elif hasattr(cls, "_setattr_with_dependants"):
+            cls._setattr_default = cls._setattr_with_dependants
         return cls
 
 
@@ -414,6 +416,23 @@ class EventedModel(BaseModel, metaclass=EventedMetaclass):
                 self._changes_queue[dep] = getattr(self, dep, object())
         self._super_setattr_(name, value)
 
+    def _setattr_default(self, name: str, value: Any) -> None:
+        """Will be overwritten by metaclass __new__."""
+
+    def _setattr_with_dependants(self, name: str, value: Any) -> None:
+        with ComparisonDelayer(self):
+            self._setattr_impl(name, value)
+
+    def _setattr_no_dependants(self, name: str, value: Any) -> None:
+        group = self._events
+        signal_instance: SignalInstance = group[name]
+        if len(signal_instance) < 1:
+            return self._super_setattr_(name, value)
+        old_value = getattr(self, name, object())
+        self._super_setattr_(name, value)
+        if not _check_field_equality(type(self), name, value, old_value):
+            getattr(self._events, name)(value)
+
     def __setattr__(self, name: str, value: Any) -> None:
         if (
             name == "_events"
@@ -422,8 +441,7 @@ class EventedModel(BaseModel, metaclass=EventedMetaclass):
         ):
             # fallback to default behavior
             return self._super_setattr_(name, value)
-        with ComparisonDelayer(self):
-            self._setattr_impl(name, value)
+        self._setattr_default(name, value)
 
     # expose the private SignalGroup publicly
     @property
@@ -524,20 +542,3 @@ def _get_defaults(obj: BaseModel) -> Dict[str, Any]:
             d = _get_defaults(v.type_)  # pragma: no cover
         dflt[k] = d
     return dflt
-
-
-class ComparisonDelayer:
-    def __init__(self, target: EventedModel) -> None:
-        self._target = target
-
-    def __enter__(self) -> None:
-        self._target._delay_check_semaphore += 1
-
-    def __exit__(
-        self,
-        exc_type: Optional[Type[BaseException]],
-        exc_val: Optional[BaseException],
-        exc_tb: Optional[TracebackType],
-    ) -> None:
-        self._target._delay_check_semaphore -= 1
-        self._target._check_if_values_changed_and_emit_if_needed()

--- a/src/psygnal/_evented_model_v1.py
+++ b/src/psygnal/_evented_model_v1.py
@@ -535,7 +535,7 @@ class ComparisonDelayer:
 
     def __exit__(
         self,
-        exc_type: Optional[type[BaseException]],
+        exc_type: Optional[Type[BaseException]],
         exc_val: Optional[BaseException],
         exc_tb: Optional[TracebackType],
     ) -> None:

--- a/src/psygnal/_evented_model_v1.py
+++ b/src/psygnal/_evented_model_v1.py
@@ -361,8 +361,6 @@ class EventedModel(BaseModel, metaclass=EventedMetaclass):
         for name in self._primary_changes:
             # primary changes should contains only fields
             # that are changed directly by assigment
-            if name not in self._changes_queue:
-                continue
             old_value = self._changes_queue[name]
             new_value = getattr(self, name)
             if not _check_field_equality(type(self), name, new_value, old_value):

--- a/src/psygnal/_evented_model_v1.py
+++ b/src/psygnal/_evented_model_v1.py
@@ -159,8 +159,8 @@ class EventedMetaclass(pydantic_main.ModelMetaclass):
         cls.__signal_group__ = type(f"{name}SignalGroup", (SignalGroup,), signals)
         if not cls.__field_dependents__ and hasattr(cls, "_setattr_no_dependants"):
             cls._setattr_default = cls._setattr_no_dependants
-        elif hasattr(cls, "_setattr_with_dependants"):
-            cls._setattr_default = cls._setattr_with_dependants
+        elif hasattr(cls, "_setattr_with_dependents"):
+            cls._setattr_default = cls._setattr_with_dependents
         return cls
 
 
@@ -419,7 +419,7 @@ class EventedModel(BaseModel, metaclass=EventedMetaclass):
     def _setattr_default(self, name: str, value: Any) -> None:
         """Will be overwritten by metaclass __new__."""
 
-    def _setattr_with_dependants(self, name: str, value: Any) -> None:
+    def _setattr_with_dependents(self, name: str, value: Any) -> None:
         with ComparisonDelayer(self):
             self._setattr_impl(name, value)
 

--- a/src/psygnal/_evented_model_v2.py
+++ b/src/psygnal/_evented_model_v2.py
@@ -347,8 +347,6 @@ class EventedModel(BaseModel, metaclass=EventedMetaclass):
         for name in self._primary_changes:
             # primary changes should contains only fields
             # that are changed directly by assigment
-            if name not in self._changes_queue:
-                continue
             old_value = self._changes_queue[name]
             new_value = getattr(self, name)
             if not _check_field_equality(type(self), name, new_value, old_value):

--- a/src/psygnal/_evented_model_v2.py
+++ b/src/psygnal/_evented_model_v2.py
@@ -528,7 +528,7 @@ class ComparisonDelayer:
 
     def __exit__(
         self,
-        exc_type: Optional[type[BaseException]],
+        exc_type: Optional[Type[BaseException]],
         exc_val: Optional[BaseException],
         exc_tb: Optional[TracebackType],
     ) -> None:

--- a/src/psygnal/_evented_model_v2.py
+++ b/src/psygnal/_evented_model_v2.py
@@ -19,6 +19,7 @@ from pydantic import BaseModel, ConfigDict, PrivateAttr
 from pydantic._internal import _model_construction, _utils
 from pydantic.fields import Field, FieldInfo
 
+from ._evented_model_utils import ComparisonDelayer
 from ._group import SignalGroup
 from ._group_descriptor import _check_field_equality, _pick_equality_operator
 from ._signal import Signal, SignalInstance
@@ -285,7 +286,7 @@ class EventedModel(BaseModel, metaclass=EventedMetaclass):
 
         class Config:
             allow_property_setters = True
-            property_dependencies = {"c": ["a", "b"]}
+            field_dependencies = {"c": ["a", "b"]}
 
     m = MyModel()
     assert m.c == [1, 1]
@@ -306,6 +307,9 @@ class EventedModel(BaseModel, metaclass=EventedMetaclass):
     __eq_operators__: ClassVar[Dict[str, "EqOperator"]]
     __slots__ = {"__weakref__"}
     __signal_group__: ClassVar[Type[SignalGroup]]
+    _changes_queue: Dict[str, Any] = PrivateAttr(default_factory=dict)
+    _primary_changes: Set[str] = PrivateAttr(default_factory=set)
+    _delay_check_semaphore: int = PrivateAttr(0)
     # pydantic BaseModel configuration.  see:
     # https://pydantic-docs.helpmanual.io/usage/model_config/
 
@@ -329,19 +333,50 @@ class EventedModel(BaseModel, metaclass=EventedMetaclass):
         else:
             super().__setattr__(name, value)
 
-    def __setattr__(self, name: str, value: Any) -> None:
-        if (
-            name == "_events"
-            or not hasattr(self, "_events")  # can happen on init
-            or name not in self._events
-        ):
-            # fallback to default behavior
-            return self._super_setattr_(name, value)
+    def _check_if_values_changed_and_emit_if_needed(self) -> None:
+        """
+        Check if field values changed and emit events if needed.
 
+        The advantage of moving this to the end of all the modifications is
+        that comparisons will be performed only once for every potential change.
+        """
+        if self._delay_check_semaphore > 0 or len(self._changes_queue) == 0:
+            # do not run whole machinery if there is no need
+            return
+        to_emit = []
+        for name in self._primary_changes:
+            # primary changes should contains only fields
+            # that are changed directly by assigment
+            if name not in self._changes_queue:
+                continue
+            old_value = self._changes_queue[name]
+            new_value = getattr(self, name)
+            if not _check_field_equality(type(self), name, new_value, old_value):
+                to_emit.append((name, new_value))
+            self._changes_queue.pop(name)
+        if not to_emit:
+            # If no direct changes was made then we can skip whole machinery
+            self._changes_queue.clear()
+            self._primary_changes.clear()
+            return
+        for name, old_value in self._changes_queue.items():
+            # check if any of dependent properties changed
+            new_value = getattr(self, name)
+            if not _check_field_equality(type(self), name, new_value, old_value):
+                to_emit.append((name, new_value))
+        self._changes_queue.clear()
+        self._primary_changes.clear()
+
+        with ComparisonDelayer(self):
+            # Again delay comparison to avoid having events caused by callback functions
+            for name, new_value in to_emit:
+                getattr(self._events, name)(new_value)
+
+    def _setattr_impl(self, name: str, value: Any) -> None:
         # if there are no listeners, we can just set the value without emitting
         # so first check if there are any listeners for this field or any of its
         # dependent properties.
-        # note that ALL signals will have sat least one listener simply by nature of
+        # note that ALL signals will have at least one listener simply by nature of
         # being in the `self._events` SignalGroup.
         group = self._events
         signal_instance: SignalInstance = group[name]
@@ -356,28 +391,25 @@ class EventedModel(BaseModel, metaclass=EventedMetaclass):
             and not len(group._psygnal_relay)  # no listeners on the SignalGroup
         ):
             return self._super_setattr_(name, value)
+        self._primary_changes.add(name)
+        if name not in self._changes_queue:
+            self._changes_queue[name] = getattr(self, name, object())
 
-        # grab the current value and those of any dependent properties
-        # so that we can check if they have changed after setting the value
-        before = getattr(self, name, object())
-        deps_before: Dict[str, Any] = {
-            dep: getattr(self, dep) for dep in deps_with_callbacks
-        }
+        for dep in deps_with_callbacks:
+            if dep not in self._changes_queue:
+                self._changes_queue[dep] = getattr(self, dep, object())
+        self._super_setattr_(name, value)
 
-        # set value using original setter
-        with signal_instance.blocked():
-            self._super_setattr_(name, value)
-
-        # if the value has changed we emit the event with new value
-        after = getattr(self, name)
-        if not _check_field_equality(type(self), name, after, before):
-            signal_instance.emit(after)  # emit event
-
-            # also emit events for any dependent attributes that have changed as well
-            for dep, before_val in deps_before.items():
-                after_val = getattr(self, dep)
-                if not _check_field_equality(type(self), dep, after_val, before_val):
-                    getattr(self._events, dep).emit(after_val)
+    def __setattr__(self, name: str, value: Any) -> None:
+        if (
+            name == "_events"
+            or not hasattr(self, "_events")  # can happen on init
+            or name not in self._events
+        ):
+            # fallback to default behavior
+            return self._super_setattr_(name, value)
+        with ComparisonDelayer(self):
+            self._setattr_impl(name, value)
 
     # expose the private SignalGroup publically
     @property

--- a/src/psygnal/_evented_model_v2.py
+++ b/src/psygnal/_evented_model_v2.py
@@ -156,8 +156,8 @@ class EventedMetaclass(_model_construction.ModelMetaclass):
         cls.__signal_group__ = type(f"{name}SignalGroup", (SignalGroup,), signals)
         if not cls.__field_dependents__ and hasattr(cls, "_setattr_no_dependants"):
             cls._setattr_default = cls._setattr_no_dependants
-        elif hasattr(cls, "_setattr_with_dependants"):
-            cls._setattr_default = cls._setattr_with_dependants
+        elif hasattr(cls, "_setattr_with_dependents"):
+            cls._setattr_default = cls._setattr_with_dependents
         return cls
 
 
@@ -405,7 +405,7 @@ class EventedModel(BaseModel, metaclass=EventedMetaclass):
     def _setattr_default(self, name: str, value: Any) -> None:
         """Will be overwritten by metaclass __new__."""
 
-    def _setattr_with_dependants(self, name: str, value: Any) -> None:
+    def _setattr_with_dependents(self, name: str, value: Any) -> None:
         with ComparisonDelayer(self):
             self._setattr_impl(name, value)
 

--- a/tests/test_evented_model.py
+++ b/tests/test_evented_model.py
@@ -850,7 +850,8 @@ def test_connect_only_to_events() -> None:
     mock1.assert_called_once()
 
 
-def test_single_emit():
+def test_if_event_is_emited_only_once():
+    """Check if, for complex property setters, the event is emitted only once."""
     class SampleClass(EventedModel):
         a: int = 1
         b: int = 2

--- a/tests/test_evented_model.py
+++ b/tests/test_evented_model.py
@@ -850,7 +850,7 @@ def test_connect_only_to_events() -> None:
     mock1.assert_called_once()
 
 
-def test_if_event_is_emited_only_once():
+def test_if_event_is_emitted_only_once():
     """Check if, for complex property setters, the event is emitted only once."""
 
     class SampleClass(EventedModel):

--- a/tests/test_evented_model.py
+++ b/tests/test_evented_model.py
@@ -850,11 +850,6 @@ def test_connect_only_to_events() -> None:
     mock1.assert_called_once()
 
 
-def _reset_mocks(*args):
-    for el in args:
-        el.reset_mock()
-
-
 def test_single_emit():
     class SampleClass(EventedModel):
         a: int = 1
@@ -873,11 +868,11 @@ def test_single_emit():
 
         @property
         def c(self):
-            return self.a
+            return self.a + self.b
 
         @c.setter
         def c(self, value):
-            self.a = value
+            self.a = value - self.b
 
         @property
         def d(self):
@@ -888,14 +883,6 @@ def test_single_emit():
             self.a = value // 2
             self.b = value - self.a
 
-        @property
-        def e(self):
-            return self.a - self.b
-
-        @e.setter
-        def e(self, value):
-            self.a = value + self.b
-
     s = SampleClass()
     a_m = Mock()
     c_m = Mock()
@@ -904,25 +891,7 @@ def test_single_emit():
     s.events.c.connect(c_m)
     s.events.d.connect(d_m)
 
-    s.a = 4
+    s.d = 5
     a_m.assert_called_once()
     c_m.assert_called_once()
     d_m.assert_called_once()
-
-    _reset_mocks(a_m, c_m, d_m)
-
-    s.c = 6
-    a_m.assert_called_once()
-    c_m.assert_called_once()
-    d_m.assert_called_once()
-
-    _reset_mocks(a_m, c_m, d_m)
-
-    e_m = Mock()
-    s.events.e.connect(e_m)
-
-    s.d = 21
-    a_m.assert_called_once()
-    c_m.assert_called_once()
-    d_m.assert_called_once()
-    e_m.assert_called_once()

--- a/tests/test_evented_model.py
+++ b/tests/test_evented_model.py
@@ -845,3 +845,75 @@ def test_connect_only_to_events() -> None:
         m.a = 3
     check_mock.assert_has_calls([call(Model, "a", 3, 1)])
     mock1.assert_called_once()
+
+
+def _reset_mocks(*args):
+    for el in args:
+        el.reset_mock()
+
+
+@pytest.mark.filterwarnings("ignore:.*Support for class-based.*:DeprecationWarning")
+def test_single_emit():
+    class SampleClass(EventedModel):
+        a: int = 1
+        b: int = 2
+
+        class Config:
+            allow_property_setters = True
+            field_dependencies = {"c": ["a"], "d": ["a", "b"], "e": ["a", "b"]}
+
+        @property
+        def c(self):
+            return self.a
+
+        @c.setter
+        def c(self, value):
+            self.a = value
+
+        @property
+        def d(self):
+            return self.a + self.b
+
+        @d.setter
+        def d(self, value):
+            self.a = value // 2
+            self.b = value - self.a
+
+        @property
+        def e(self):
+            return self.a - self.b
+
+        @e.setter
+        def e(self, value):
+            self.a = value + self.b
+
+    s = SampleClass()
+    a_m = Mock()
+    c_m = Mock()
+    d_m = Mock()
+    s.events.a.connect(a_m)
+    s.events.c.connect(c_m)
+    s.events.d.connect(d_m)
+
+    s.a = 4
+    a_m.assert_called_once()
+    c_m.assert_called_once()
+    d_m.assert_called_once()
+
+    _reset_mocks(a_m, c_m, d_m)
+
+    s.c = 6
+    a_m.assert_called_once()
+    c_m.assert_called_once()
+    d_m.assert_called_once()
+
+    _reset_mocks(a_m, c_m, d_m)
+
+    e_m = Mock()
+    s.events.e.connect(e_m)
+
+    s.d = 21
+    a_m.assert_called_once()
+    c_m.assert_called_once()
+    d_m.assert_called_once()
+    e_m.assert_called_once()

--- a/tests/test_evented_model.py
+++ b/tests/test_evented_model.py
@@ -852,6 +852,7 @@ def test_connect_only_to_events() -> None:
 
 def test_if_event_is_emited_only_once():
     """Check if, for complex property setters, the event is emitted only once."""
+
     class SampleClass(EventedModel):
         a: int = 1
         b: int = 2


### PR DESCRIPTION
This PR migrates https://github.com/napari/napari/pull/6075 into psygnal to deduplicated event emission.

This will allow in future to drop the `napari.utils.events` module.