### PR TITLE
chore: remove asynchronous emit and other deprecations

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -348,63 +348,6 @@ app.processEvents()  # or app.exec_(), or anything to keep the event loop runnin
 It is ok to call `start_emitting_from_queue` multiple times (so multiple
 end-users can use it).
 
-## Asynchronous Signal Emission
-
-!!!warning "Deprecated"
-
-    This feature is deprecated and will be removed in a future release.
-    Its use is not recommended in new code. If you need to emit signals
-    in a background thread, please create your own [`threading.Thread`][]
-    and call `emit` from within that thread.
-
-There is ~~experimental~~ **deprecated** support for calling all connected slots
-in another thread, using `emit(..., asynchronous=True)`
-
-```py
-obj = MyObj()
-
-def slow_callback(arg):
-    import time
-    time.sleep(0.5)
-    print(f"Hi {arg!r}, from another thread")
-
-obj.value_changed.connect(slow_callback)
-```
-
-This one is called synchronously (note the order of print statements):
-
-```py
-obj.value_changed.emit('friend')
-print("Hi, from main thread.")
-
-# after 0.5 seconds, prints:
-# Hi 'friend', from another thread
-# Hi, from main thread.
-```
-
-This one is called asynchronously, and immediately returns to the caller.
-A `threading.Thread` object is returned.
-
-```py
-thread = obj.value_changed.emit('friend', asynchronous=True)
-print("Hi, from main thread.")
-
-# immediately prints
-# Hi, from main thread.
-
-# then after 0.5 seconds this will print:
-# Hi 'friend', from another thread
-```
-
-**Note:** The user is responsible for `joining` and managing the
-`threading.Thread` instance returned when calling `.emit(...,
-asynchronous=True)`.
-
-**Experimental!**  While thread-safety is the goal,
-([`RLocks`](https://docs.python.org/3/library/threading.html#rlock-objects) are
-used during important state mutations) it is not guaranteed.  Please use at your
-own risk. Issues/PRs welcome.
-
 ## Blocking a Signal
 
 To temporarily block a signal, use the `signal.blocked()` context context manager:

--- a/src/psygnal/_signal.py
+++ b/src/psygnal/_signal.py
@@ -561,7 +561,7 @@ class SignalInstance:
 
     def connect_setattr(
         self,
-        obj: weakref.ref | object,
+        obj: object,
         attr: str,
         maxargs: int | None | object = _NULL,
         *,
@@ -577,8 +577,8 @@ class SignalInstance:
 
         Parameters
         ----------
-        obj : Union[weakref.ref, object]
-            An object or weak reference (deprecated) to an object.
+        obj : object
+            An object.
         attr : str
             The name of an attribute on `obj` that should be set to the value of this
             signal when emitted.
@@ -627,15 +627,6 @@ class SignalInstance:
             )
             maxargs = None
 
-        if isinstance(obj, weakref.ReferenceType):  # pragma: no cover
-            warnings.warn(
-                'Using a weakref as the "obj" argument is deprecated. '
-                "Use the object directly instead. This will raise an error in "
-                "a future release.",
-                FutureWarning,
-                stacklevel=2,
-            )
-            obj = obj()
         if not hasattr(obj, attr):
             raise AttributeError(f"Object {obj} has no attribute {attr!r}")
 
@@ -678,7 +669,7 @@ class SignalInstance:
 
     def connect_setitem(
         self,
-        obj: weakref.ref | object,
+        obj: object,
         key: str,
         maxargs: int | None | object = _NULL,
         *,
@@ -694,8 +685,8 @@ class SignalInstance:
 
         Parameters
         ----------
-        obj : Union[weakref.ref, object]
-            An object or weak reference (deprecated) to an object.
+        obj : object
+            An object.
         key : str
             Name of the key in `obj` that should be set to the value of this
             signal when emitted
@@ -741,21 +732,12 @@ class SignalInstance:
             )
             maxargs = None
 
-        if isinstance(obj, weakref.ReferenceType):  # pragma: no cover
-            warnings.warn(
-                'Using a weakref as the "obj" argument is deprecated. '
-                "Use the object directly instead. This will raise an error in "
-                "a future release.",
-                FutureWarning,
-                stacklevel=2,
-            )
-            obj = obj()
         if not hasattr(obj, "__setitem__"):
             raise TypeError(f"Object {obj} does not support __setitem__")
 
         with self._lock:
             caller = WeakSetitem(
-                obj,  # type: ignore
+                obj,
                 key,
                 max_args=cast("int | None", maxargs),
                 finalize=self._try_discard,
@@ -890,33 +872,9 @@ class SignalInstance:
         """Return number of connected slots."""
         return len(self._slots)
 
-    @overload
     def emit(
-        self,
-        *args: Any,
-        check_nargs: bool = False,
-        check_types: bool = False,
-        asynchronous: Literal[False] = False,
-    ) -> None: ...  # pragma: no cover
-
-    @overload
-    def emit(
-        self,
-        *args: Any,
-        check_nargs: bool = False,
-        check_types: bool = False,
-        asynchronous: Literal[True],
-    ) -> EmitThread | None:
-        # will return `None` if emitter is blocked
-        ...  # pragma: no cover
-
-    def emit(
-        self,
-        *args: Any,
-        check_nargs: bool = False,
-        check_types: bool = False,
-        asynchronous: bool = False,
-    ) -> EmitThread | None:
+        self, *args: Any, check_nargs: bool = False, check_types: bool = False
+    ) -> None:
         """Emit this signal with arguments `args`.
 
         !!! note
@@ -936,13 +894,6 @@ class SignalInstance:
             If `False` and the provided arguments do not match the types declared by
             the signature of this Signal, raise `TypeError`.  Incurs some overhead.
             by default False.
-        asynchronous : bool
-            If `True`, run signal emission in another thread. by default `False`.
-            **DEPRECATED:**. *If you need to emit from a thread, please just create
-            your own [`threading.Thread`][] and call
-            [`SignalInstance.emit`][psygnal.SignalInstance.emit]. See also the `thread`
-            parameter in the [`SignalInstance.connect`][psygnal.SignalInstance.connect]
-            method.*
 
         Raises
         ------
@@ -980,55 +931,17 @@ class SignalInstance:
 
             SignalInstance._debug_hook(EmissionInfo(self, args))
 
-        if asynchronous:
-            warnings.warn(
-                "The `asynchronous` parameter is deprecated and will be removed in a "
-                "future release. If you need this, please create your own "
-                "`threading.Thread` and call `SignalInstance.emit`. See also the new "
-                "`thread` parameter in the `SignalInstance.connect` method.",
-                FutureWarning,
-                stacklevel=2,
-            )
-            sd = EmitThread(self, args)
-            sd.start()
-            return sd
-
         self._run_emit_loop(args)
         return None
 
-    @overload
     def __call__(
-        self,
-        *args: Any,
-        check_nargs: bool = False,
-        check_types: bool = False,
-        asynchronous: Literal[False] = False,
-    ) -> None: ...  # pragma: no cover
-
-    @overload
-    def __call__(
-        self,
-        *args: Any,
-        check_nargs: bool = False,
-        check_types: bool = False,
-        asynchronous: Literal[True],
-    ) -> EmitThread | None:
-        # will return `None` if emitter is blocked
-        ...  # pragma: no cover
-
-    def __call__(
-        self,
-        *args: Any,
-        check_nargs: bool = False,
-        check_types: bool = False,
-        asynchronous: bool = False,
-    ) -> EmitThread | None:
+        self, *args: Any, check_nargs: bool = False, check_types: bool = False
+    ) -> None:
         """Alias for `emit()`."""
-        return self.emit(  # type: ignore
+        return self.emit(
             *args,
             check_nargs=check_nargs,
             check_types=check_types,
-            asynchronous=asynchronous,
         )
 
     def _run_emit_loop(self, args: tuple[Any, ...]) -> None:
@@ -1249,21 +1162,6 @@ class _SignalPauser:
     def __exit__(self, *args: Any) -> None:
         if not self._was_paused:
             self._signal.resume(self._reducer, self._initial)
-
-
-class EmitThread(threading.Thread):
-    """A thread to emit a signal asynchronously."""
-
-    def __init__(self, signal_instance: SignalInstance, args: tuple[Any, ...]) -> None:
-        super().__init__(name=signal_instance.name)
-        self._signal_instance = signal_instance
-        self.args = args
-        # current = threading.currentThread()
-        # self.parent = (current.getName(), current.ident)
-
-    def run(self) -> None:
-        """Run thread."""
-        self._signal_instance._run_emit_loop(self.args)
 
 
 # #############################################################################

--- a/typesafety/test_signal.yml
+++ b/typesafety/test_signal.yml
@@ -19,13 +19,6 @@
     s = Signal(Signature())
     s = Signal(1) # ER: Argument 1 to "Signal" has incompatible type "int"; .*
 
-- case: signal_emit
-  main: |
-    from psygnal import SignalInstance
-    s = SignalInstance()
-    x = s.emit(1)
-    reveal_type(x)  # N: Revealed type is "None"
-
 - case: signal_connection
   main: |
     from psygnal import SignalInstance

--- a/typesafety/test_signal.yml
+++ b/typesafety/test_signal.yml
@@ -26,9 +26,6 @@
     x = s.emit(1)
     reveal_type(x)  # N: Revealed type is "None"
 
-    y = s.emit(1, asynchronous=True)
-    reveal_type(y)  # N: Revealed type is "Union[psygnal._signal.EmitThread, None]"
-
 - case: signal_connection
   main: |
     from psygnal import SignalInstance


### PR DESCRIPTION
`emit(asynchronous=True)` has been depreacted for a year now.  This removes it along with some other old deprecations.