### PR TITLE
feat: add priority to connect, to control callback order

### DIFF
--- a/src/psygnal/_group.py
+++ b/src/psygnal/_group.py
@@ -440,6 +440,7 @@ class SignalGroup:
         unique: bool | str = ...,
         max_args: int | None = None,
         on_ref_error: RefErrorChoice = ...,
+        priority: int = ...,
     ) -> Callable[[F], F]: ...
 
     @overload
@@ -453,6 +454,7 @@ class SignalGroup:
         unique: bool | str = ...,
         max_args: int | None = None,
         on_ref_error: RefErrorChoice = ...,
+        priority: int = ...,
     ) -> F: ...
 
     def connect(
@@ -465,6 +467,7 @@ class SignalGroup:
         unique: bool | str = False,
         max_args: int | None = None,
         on_ref_error: RefErrorChoice = "warn",
+        priority: int = 0,
     ) -> Callable[[F], F] | F:
         if slot is None:
             return self._psygnal_relay.connect(
@@ -474,6 +477,7 @@ class SignalGroup:
                 unique=unique,
                 max_args=max_args,
                 on_ref_error=on_ref_error,
+                priority=priority,
             )
         else:
             return self._psygnal_relay.connect(
@@ -484,6 +488,7 @@ class SignalGroup:
                 unique=unique,
                 max_args=max_args,
                 on_ref_error=on_ref_error,
+                priority=priority,
             )
 
     def connect_direct(

--- a/src/psygnal/_group_descriptor.py
+++ b/src/psygnal/_group_descriptor.py
@@ -134,8 +134,11 @@ class _DataclassFieldSignalInstance(SignalInstance):
         maxargs: int | None | object = 1,
         *,
         on_ref_error: RefErrorChoice = "warn",
+        priority: int = 0,
     ) -> WeakCallback[None]:
-        return super().connect_setattr(obj, attr, maxargs, on_ref_error=on_ref_error)
+        return super().connect_setattr(
+            obj, attr, maxargs, on_ref_error=on_ref_error, priority=priority
+        )
 
 
 @lru_cache(maxsize=None)

--- a/src/psygnal/_queue.py
+++ b/src/psygnal/_queue.py
@@ -57,6 +57,7 @@ class QueuedCallback(WeakCallback):
         # NOTE: for some strange reason, mypyc crashes if we use `self._thread` here
         # so we use `self._thred` instead
         self._thred = thread
+        self.priority: int = wrapped.priority
 
     def cb(self, args: tuple = ()) -> None:
         if current_thread() is self._thred:

--- a/src/psygnal/_signal.py
+++ b/src/psygnal/_signal.py
@@ -493,7 +493,6 @@ class SignalInstance:
             Higher priority callbacks are called first. Negative values are allowed.
             The default is 0.
 
-
         Raises
         ------
         TypeError

--- a/src/psygnal/_signal.py
+++ b/src/psygnal/_signal.py
@@ -1167,6 +1167,7 @@ class SignalInstance:
             "_check_nargs_on_connect",
             "_check_types_on_connect",
             "_emit_queue",
+            "_priority_in_use",
         )
         dd = {slot: getattr(self, slot) for slot in attrs}
         dd["_instance"] = self._instance()

--- a/src/psygnal/_signal.py
+++ b/src/psygnal/_signal.py
@@ -342,6 +342,7 @@ class SignalInstance:
         self._is_paused: bool = False
         self._lock = threading.RLock()
         self._emit_queue: list[tuple] = []
+        self._priority_in_use = False
 
     @staticmethod
     def _instance_ref(instance: Any) -> Callable[[], Any]:
@@ -542,8 +543,15 @@ class SignalInstance:
         return _wrapper if slot is None else _wrapper(slot)
 
     def _append_slot(self, slot: WeakCallback) -> None:
-        """Append a slot to the list of slots."""
-        # implementing this as a method allows us to override/extend it in subclasses
+        """Append a slot to the list of slots.
+
+        Implementing this as a method allows us to override/extend it in subclasses.
+        """
+        if not self._priority_in_use:
+            if not slot.priority:
+                self._slots.append(slot)
+                return
+            self._priority_in_use = True
 
         # insert the slot in the correct position based on priority
         # high priority slots are at the front of the list

--- a/tests/test_psygnal.py
+++ b/tests/test_psygnal.py
@@ -1038,3 +1038,18 @@ def test_signal_order_suspend():
 
     mock1.assert_has_calls([call(1), call(10), call(11), call(39)])
     mock2.assert_has_calls([call(1), call(10), call(11), call(39)])
+
+
+def test_call_priority() -> None:
+    """Test that signals are emitted in the order they were connected."""
+    emitter = Emitter()
+
+    calls = []
+
+    emitter.no_arg.connect(lambda: calls.append(1))
+    emitter.no_arg.connect(lambda: calls.append(2), priority=5)
+    emitter.no_arg.connect(lambda: calls.append(3), priority=-5)
+    emitter.no_arg.connect(lambda: calls.append(4), priority=10)
+
+    emitter.no_arg.emit()
+    assert calls == [4, 2, 1, 3]


### PR DESCRIPTION
This adds the ability to control the order in which callbacks are called at connection time.  Higher priority connections are called first, and negative priorities are allowed.  with default 0

```python
sig = SignalInstance()

calls = []

sig.connect(lambda: calls.append(1))
sig.connect(lambda: calls.append(2), priority=5)
sig.connect(lambda: calls.append(3), priority=-5)
sig.connect(lambda: calls.append(4), priority=10)

sig.emit()
assert calls == [4, 2, 1, 3]
```

