### PR TITLE
chore: un-deprecate SignalGroup.signals

### DIFF
--- a/src/psygnal/_group.py
+++ b/src/psygnal/_group.py
@@ -359,16 +359,16 @@ class SignalGroup:
 
     @property
     def signals(self) -> Mapping[str, SignalInstance]:
-        """DEPRECATED: A mapping of signal names to SignalInstance instances."""
+        """A mapping of signal names to SignalInstance instances."""
         # TODO: deprecate this property
-        warnings.warn(
-            "Accessing the `signals` property on a SignalGroup is deprecated. "
-            "Use __iter__ to iterate over all signal names, and __getitem__ or getattr "
-            "to access signal instances. This will be an error in a future.",
-            FutureWarning,
-            stacklevel=2,
-        )
-        return self._psygnal_instances
+        # warnings.warn(
+        #     "Accessing the `signals` property on a SignalGroup is deprecated. "
+        #     "Use __iter__ to iterate over all signal names, and __getitem__ or "
+        #     "getattr to access signal instances. This will be an error in a future.",
+        #     FutureWarning,
+        #     stacklevel=2,
+        # )
+        return MappingProxyType(self._psygnal_instances)
 
     def __len__(self) -> int:
         """Return the number of signals in the group (not including the relay)."""

--- a/src/psygnal/_signal.py
+++ b/src/psygnal/_signal.py
@@ -664,7 +664,7 @@ class SignalInstance:
         """
         if maxargs is _NULL:
             warnings.warn(
-                "The default value of maxargs will change from `None` to `1` in"
+                "The default value of maxargs will change from `None` to `1` in "
                 "version 0.11. To silence this warning, provide an explicit value for "
                 "maxargs (`None` for current behavior, `1` for future behavior).",
                 FutureWarning,

--- a/tests/test_evented_model.py
+++ b/tests/test_evented_model.py
@@ -69,9 +69,9 @@ def test_evented_model():
 
     # test event system
     assert isinstance(user.events, SignalGroup)
-    with pytest.warns(FutureWarning):
-        assert "id" in user.events.signals
-        assert "name" in user.events.signals
+    # with pytest.warns(FutureWarning):
+    assert "id" in user.events.signals
+    assert "name" in user.events.signals
 
     # ClassVars are excluded from events
     assert "age" not in user.events


### PR DESCRIPTION
couple minor changes before releasing v0.10.0

this removes the deprecation of SignalGroup.signals, delaying the decision for a later version