### PR TITLE
Add recursion_mode ('immediate' or 'deferred') to Signal and SignalInstance

### DIFF
--- a/src/psygnal/containers/_evented_set.py
+++ b/src/psygnal/containers/_evented_set.py
@@ -218,7 +218,7 @@ class SetEvents(SignalGroup):
         added or removed from the set.
     """
 
-    items_changed = Signal(tuple, tuple)
+    items_changed = Signal(tuple, tuple, recursion_mode="deferred")
 
 
 class EventedSet(_BaseMutableSet[_T]):

--- a/tests/test_psygnal.py
+++ b/tests/test_psygnal.py
@@ -980,7 +980,7 @@ def test_pickle():
 
 @pytest.mark.skipif(PY39 and WINDOWS and COMPILED, reason="fails")
 def test_recursion_error() -> None:
-    s = SignalInstance()
+    s = SignalInstance(recursion_mode="deferred")
 
     @s.connect
     def callback() -> None:
@@ -1025,30 +1025,30 @@ def test_callback_order(recursion: Literal["immediate", "deferred"]) -> None:
 
 def test_signal_order_suspend():
     """Test that signals are emitted in the order they were connected."""
-    emitter = Emitter()
+    sig = SignalInstance((int,), recursion_mode="deferred")
     mock1 = Mock()
     mock2 = Mock()
 
     def callback(x):
         if x < 10:
-            emitter.one_int.emit(10)
+            sig.emit(10)
 
     def callback2(x):
         if x == 10:
-            emitter.one_int.emit(11)
+            sig.emit(11)
 
     def callback3(x):
         if x == 10:
-            with emitter.one_int.paused(reducer=lambda a, b: (a[0] + b[0],)):
+            with sig.paused(reducer=lambda a, b: (a[0] + b[0],)):
                 for i in range(12, 15):
-                    emitter.one_int.emit(i)
+                    sig.emit(i)
 
-    emitter.one_int.connect(mock1)
-    emitter.one_int.connect(callback)
-    emitter.one_int.connect(callback2)
-    emitter.one_int.connect(callback3)
-    emitter.one_int.connect(mock2)
-    emitter.one_int.emit(1)
+    sig.connect(mock1)
+    sig.connect(callback)
+    sig.connect(callback2)
+    sig.connect(callback3)
+    sig.connect(mock2)
+    sig.emit(1)
 
     mock1.assert_has_calls([call(1), call(10), call(11), call(39)])
     mock2.assert_has_calls([call(1), call(10), call(11), call(39)])


### PR DESCRIPTION
fixes #292 

This adds the possibility to control the order callbacks during recursive emission events (when one of the callbacks itself emits the same event):

- `"immediate"`: Nested emission events immediately begin a deeper emission loop:
calling all callbacks with the arguments of the nested emitter before
returning to continue the original emission loop.  This is the default
behavior.
- `"deferred"`: Nested emission events are deferred until the current emission
loop is complete.  This is the default behavior.