### PR TITLE
chore: patch asv config to work locally with arm64 macos on hatchling

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -29,8 +29,7 @@ jobs:
           installer-url: https://github.com/conda-forge/miniforge/releases/latest/download/Mambaforge-Linux-x86_64.sh
       - name: install
         run: |
-          pip install -U wheel
-          pip install -U asv
+          pip install -U wheel asv
           git checkout main && git checkout -
           asv machine --machine github-actions --yes
 

--- a/Makefile
+++ b/Makefile
@@ -28,12 +28,12 @@ clean:
 # run benchmarks for all commits since v0.1.0
 benchmark-all:
 	pip install asv
-	asv run -j 8 --show-stderr --interleave-processes --skip-existing v0.2.0..HEAD
+	MACOSX_DEPLOYMENT_TARGET=11.0 asv run -j 8 --show-stderr --interleave-processes --skip-existing v0.2.0..HEAD
 
 # compare HEAD against main
 benchmark-compare:
-	asv run --interleave-processes --skip-existing main^!
-	asv run --interleave-processes HEAD^!
+	MACOSX_DEPLOYMENT_TARGET=11.0 asv run --interleave-processes --skip-existing main^!
+	MACOSX_DEPLOYMENT_TARGET=11.0 asv run --interleave-processes HEAD^!
 	asv compare --split --factor 1.15 main HEAD
 
 typetest:

--- a/asv.conf.json
+++ b/asv.conf.json
@@ -10,8 +10,9 @@
   "show_commit_url": "https://github.com/pyapp-kit/psygnal/commit/",
   "pythons": ["3.11"],
   "build_command": [
-    "python -m pip install build",
-    "python -m build --wheel -o {build_cache_dir} {build_dir}"
+    "python -m pip install build 'hatchling==1.21.1' hatch-mypyc types-attrs mypy",
+    "python -c \"import os; from pathlib import Path; import hatchling.builders.wheel as h; p = Path(h.__file__); targ = os.environ.get('MACOSX_DEPLOYMENT_TARGET', '10_16').replace('.', '_'); txt = p.read_text().replace('10_16', targ); p.write_text(txt)\"",
+    "python -m build --wheel -o {build_cache_dir} {build_dir} --no-isolation"
   ],
   "install_command": [
     "python -m pip install {wheel_file}[pydantic]"

--- a/asv.conf.json
+++ b/asv.conf.json
@@ -10,7 +10,7 @@
   "show_commit_url": "https://github.com/pyapp-kit/psygnal/commit/",
   "pythons": ["3.11"],
   "build_command": [
-    "python -m pip install build 'hatchling==1.21.1' hatch-mypyc types-attrs mypy",
+    "python -m pip install build 'hatchling==1.21.1' hatch-mypyc types-attrs mypy msgspec",
     "python -c \"import os; from pathlib import Path; import hatchling.builders.wheel as h; p = Path(h.__file__); targ = os.environ.get('MACOSX_DEPLOYMENT_TARGET', '10_16').replace('.', '_'); txt = p.read_text().replace('10_16', targ); p.write_text(txt)\"",
     "python -m build --wheel -o {build_cache_dir} {build_dir} --no-isolation"
   ],

--- a/asv.conf.json
+++ b/asv.conf.json
@@ -10,7 +10,7 @@
   "show_commit_url": "https://github.com/pyapp-kit/psygnal/commit/",
   "pythons": ["3.11"],
   "build_command": [
-    "python -m pip install build 'hatchling==1.21.1' hatch-mypyc types-attrs mypy msgspec",
+    "python -m pip install build 'hatchling==1.21.1' hatch-vcs hatch-mypyc mypy pydantic types-attrs msgspec",
     "python -c \"import os; from pathlib import Path; import hatchling.builders.wheel as h; p = Path(h.__file__); targ = os.environ.get('MACOSX_DEPLOYMENT_TARGET', '10_16').replace('.', '_'); txt = p.read_text().replace('10_16', targ); p.write_text(txt)\"",
     "python -m build --wheel -o {build_cache_dir} {build_dir} --no-isolation"
   ],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,7 @@ test = [
     "pytest>=6.0",
     "pytest-cov",
     "wrapt",
-    "msgspec ; python_version >= '3.8'",
+    "msgspec",
     "toolz",
 ]
 testqt = ["pytest-qt", "qtpy"]
@@ -96,7 +96,7 @@ dependencies = [
     "mypy_extensions >=0.4.2",
     "pydantic",
     "types-attrs",
-    "msgspec ; python_version >= '3.8'",
+    "msgspec",
 ]
 exclude = [
     "src/psygnal/__init__.py",


### PR DESCRIPTION
this is an ugly fix to deal with the fact that hatchling doesn't respect MACOSX_DEPLOYMENT_TARGET, and when I try to run asv benchmarks locally, the wheel that gets created is doesn't get interpreted as compatible with the system, and can't be installed.  One fix is to set `macos-max-compat = false` in the hatch wheel settings, but I only want that to happen when benchmarking locally, and that setting doesn't seem to be switchable by an environment variable.  so this is the unfortunate solution I came up with.  

inspired by black's pyproject: https://github.com/psf/black/blob/6af7d1109693c4ad3af08ecbc34649c232b47a6d/pyproject.toml