### PR TITLE
feat: Rename `recursion_mode` to `reemission`.  Rename `deferred` to `queued`.  Add `latest-only` mode.

### DIFF
--- a/src/psygnal/_evented_model.py
+++ b/src/psygnal/_evented_model.py
@@ -220,14 +220,14 @@ class EventedMetaclass(pydantic_main.ModelMetaclass):
         default_strategy: ReemissionMode = ReemissionMode.LATEST
         emission_map: Mapping[str, ReemissionMode] = {}
         if isinstance(emission_cfg, (str, ReemissionMode)):
-            default_strategy = ReemissionMode.cast(emission_cfg)
+            default_strategy = ReemissionMode.validate(emission_cfg)
         else:
             try:
                 emission_map = {
-                    k: ReemissionMode.cast(v) for k, v in emission_cfg.items()
+                    k: ReemissionMode.validate(v) for k, v in emission_cfg.items()
                 }
             except (ValueError, TypeError) as e:
-                valid = ", ".join(repr(x.value) for x in ReemissionMode)
+                valid = ", ".join(repr(x) for x in ReemissionMode._members())
                 raise ValueError(
                     f"Invalid reemission value {emission_cfg!r}. Must be a mapping "
                     f"of field names to one of {valid}."

--- a/src/psygnal/_evented_model.py
+++ b/src/psygnal/_evented_model.py
@@ -22,7 +22,7 @@ from pydantic import PrivateAttr
 
 from ._group import SignalGroup
 from ._group_descriptor import _check_field_equality, _pick_equality_operator
-from ._signal import Signal
+from ._signal import EMISSION_STRATEGIES, Signal
 
 PYDANTIC_V1 = pydantic.version.VERSION.startswith("1")
 
@@ -34,7 +34,7 @@ if TYPE_CHECKING:
     from pydantic._internal import _utils as utils
     from typing_extensions import dataclass_transform as dataclass_transform  # py311
 
-    from ._signal import RecursionMode, SignalInstance
+    from ._signal import EmissionStrategy, SignalInstance
 
     EqOperator = Callable[[Any, Any], bool]
 else:
@@ -58,8 +58,8 @@ NULL = object()
 ALLOW_PROPERTY_SETTERS = "allow_property_setters"
 FIELD_DEPENDENCIES = "field_dependencies"
 GUESS_PROPERTY_DEPENDENCIES = "guess_property_dependencies"
-RECURSION_MODE = "recursion_mode"
-DEFAULT_RECURSION_MODE: "RecursionMode" = "deferred"
+EMISSION_STRATEGY = "emission_strategy"
+DEFAULT_EMISSION_STRATEGY: "EmissionStrategy" = "sequential"
 
 
 @contextmanager
@@ -217,31 +217,31 @@ class EventedMetaclass(pydantic_main.ModelMetaclass):
         model_fields = _get_fields(cls)
         model_config = _get_config(cls)
 
-        recursion_cfg = model_config.get(RECURSION_MODE, {})
-        default_recursion: RecursionMode = DEFAULT_RECURSION_MODE
-        recursion_map: Mapping[str, RecursionMode] = {}
-        if isinstance(recursion_cfg, str):
-            if recursion_cfg not in {"immediate", "deferred"}:
+        emission_cfg = model_config.get(EMISSION_STRATEGY, {})
+        default_strategy: EmissionStrategy = DEFAULT_EMISSION_STRATEGY
+        emission_map: Mapping[str, EmissionStrategy] = {}
+        if isinstance(emission_cfg, str):
+            if emission_cfg not in EMISSION_STRATEGIES:
                 raise ValueError(
-                    f"Invalid recursion mode {default_recursion!r}. Must be "
-                    "either 'immediate' or 'deferred'"
+                    f"Invalid emission strategy {default_strategy!r}. Must be "
+                    f"one of {EMISSION_STRATEGIES!r}"
                 )
-            default_recursion = recursion_cfg
+            default_strategy = emission_cfg
         else:
-            if not isinstance(recursion_cfg, Mapping) or not all(
-                x in {"immediate", "deferred"} for x in recursion_cfg.values()
+            if not isinstance(emission_cfg, Mapping) or not all(
+                x in EMISSION_STRATEGIES for x in emission_cfg.values()
             ):
                 raise ValueError(
-                    f"Invalid recursion mode {recursion_cfg!r}. Must be a mapping "
-                    "of field names to 'immediate' or 'deferred'."
+                    f"Invalid emission strategy {emission_cfg!r}. Must be a mapping "
+                    f"of field names to one of {EMISSION_STRATEGIES!r}."
                 )
-            recursion_map = recursion_cfg
+            emission_map = emission_cfg
 
         for n, f in model_fields.items():
             cls.__eq_operators__[n] = _pick_equality_operator(f.annotation)
             if not f.frozen:
-                recursion = recursion_map.get(n, default_recursion)
-                signals[n] = Signal(f.annotation, recursion_mode=recursion)
+                recursion = emission_map.get(n, default_strategy)
+                signals[n] = Signal(f.annotation, emission_strategy=recursion)
 
             # If a field type has a _json_encode method, add it to the json
             # encoders for this model.
@@ -269,8 +269,8 @@ class EventedMetaclass(pydantic_main.ModelMetaclass):
             for key, attr in namespace.items():
                 if isinstance(attr, property) and attr.fset is not None:
                     cls.__property_setters__[key] = attr
-                    recursion = recursion_map.get(key, default_recursion)
-                    signals[key] = Signal(object, recursion_mode=recursion)
+                    recursion = emission_map.get(key, default_strategy)
+                    signals[key] = Signal(object, emission_strategy=recursion)
         else:
             for b in cls.__bases__:
                 with suppress(AttributeError):

--- a/src/psygnal/_evented_model.py
+++ b/src/psygnal/_evented_model.py
@@ -22,7 +22,7 @@ from pydantic import PrivateAttr
 
 from ._group import SignalGroup
 from ._group_descriptor import _check_field_equality, _pick_equality_operator
-from ._signal import EMISSION_STRATEGIES, Signal
+from ._signal import ReemissionMode, Signal
 
 PYDANTIC_V1 = pydantic.version.VERSION.startswith("1")
 
@@ -34,7 +34,7 @@ if TYPE_CHECKING:
     from pydantic._internal import _utils as utils
     from typing_extensions import dataclass_transform as dataclass_transform  # py311
 
-    from ._signal import EmissionStrategy, SignalInstance
+    from ._signal import SignalInstance
 
     EqOperator = Callable[[Any, Any], bool]
 else:
@@ -58,8 +58,7 @@ NULL = object()
 ALLOW_PROPERTY_SETTERS = "allow_property_setters"
 FIELD_DEPENDENCIES = "field_dependencies"
 GUESS_PROPERTY_DEPENDENCIES = "guess_property_dependencies"
-EMISSION_STRATEGY = "emission_strategy"
-DEFAULT_EMISSION_STRATEGY: "EmissionStrategy" = "sequential"
+REEMISSION = "reemission"
 
 
 @contextmanager
@@ -217,31 +216,28 @@ class EventedMetaclass(pydantic_main.ModelMetaclass):
         model_fields = _get_fields(cls)
         model_config = _get_config(cls)
 
-        emission_cfg = model_config.get(EMISSION_STRATEGY, {})
-        default_strategy: EmissionStrategy = DEFAULT_EMISSION_STRATEGY
-        emission_map: Mapping[str, EmissionStrategy] = {}
-        if isinstance(emission_cfg, str):
-            if emission_cfg not in EMISSION_STRATEGIES:
-                raise ValueError(
-                    f"Invalid emission strategy {default_strategy!r}. Must be "
-                    f"one of {EMISSION_STRATEGIES!r}"
-                )
-            default_strategy = emission_cfg
+        emission_cfg = model_config.get(REEMISSION, {})
+        default_strategy: ReemissionMode = ReemissionMode.LATEST
+        emission_map: Mapping[str, ReemissionMode] = {}
+        if isinstance(emission_cfg, (str, ReemissionMode)):
+            default_strategy = ReemissionMode.cast(emission_cfg)
         else:
-            if not isinstance(emission_cfg, Mapping) or not all(
-                x in EMISSION_STRATEGIES for x in emission_cfg.values()
-            ):
+            try:
+                emission_map = {
+                    k: ReemissionMode.cast(v) for k, v in emission_cfg.items()
+                }
+            except (ValueError, TypeError) as e:
+                valid = ", ".join(repr(x.value) for x in ReemissionMode)
                 raise ValueError(
-                    f"Invalid emission strategy {emission_cfg!r}. Must be a mapping "
-                    f"of field names to one of {EMISSION_STRATEGIES!r}."
-                )
-            emission_map = emission_cfg
+                    f"Invalid reemission value {emission_cfg!r}. Must be a mapping "
+                    f"of field names to one of {valid}."
+                ) from e
 
         for n, f in model_fields.items():
             cls.__eq_operators__[n] = _pick_equality_operator(f.annotation)
             if not f.frozen:
                 recursion = emission_map.get(n, default_strategy)
-                signals[n] = Signal(f.annotation, emission_strategy=recursion)
+                signals[n] = Signal(f.annotation, reemission=recursion)
 
             # If a field type has a _json_encode method, add it to the json
             # encoders for this model.
@@ -270,7 +266,7 @@ class EventedMetaclass(pydantic_main.ModelMetaclass):
                 if isinstance(attr, property) and attr.fset is not None:
                     cls.__property_setters__[key] = attr
                     recursion = emission_map.get(key, default_strategy)
-                    signals[key] = Signal(object, emission_strategy=recursion)
+                    signals[key] = Signal(object, reemission=recursion)
         else:
             for b in cls.__bases__:
                 with suppress(AttributeError):

--- a/src/psygnal/_signal.py
+++ b/src/psygnal/_signal.py
@@ -202,7 +202,7 @@ class ReemissionMode:
 
     @staticmethod
     def validate(value: str) -> str:
-        value = str(value).lower().replace("_", "-")
+        value = str(value).lower()
         if value not in ReemissionMode._members():
             raise ValueError(
                 f"Invalid reemission value. Must be one of "

--- a/src/psygnal/_signal.py
+++ b/src/psygnal/_signal.py
@@ -1076,6 +1076,7 @@ class SignalInstance:
                 # we're back to the root level of the emit loop, reset max_depth
                 if self._recursion_depth <= 0:
                     self._max_recursion_depth = 0
+                    self._recursion_depth = 0
                 self._emit_queue.clear()
 
     def _run_emit_loop_immediate(self) -> None:

--- a/src/psygnal/containers/_evented_dict.py
+++ b/src/psygnal/containers/_evented_dict.py
@@ -19,7 +19,7 @@ from typing import (
 )
 
 if TYPE_CHECKING:
-    from typing import Self
+    from typing_extensions import Self
 
 from psygnal._group import SignalGroup
 from psygnal._signal import Signal

--- a/src/psygnal/containers/_evented_list.py
+++ b/src/psygnal/containers/_evented_list.py
@@ -46,7 +46,7 @@ _T = TypeVar("_T")
 Index = Union[int, slice]
 
 if TYPE_CHECKING:
-    from typing import Self
+    from typing_extensions import Self
 
 
 class ListEvents(SignalGroup):

--- a/src/psygnal/containers/_evented_set.py
+++ b/src/psygnal/containers/_evented_set.py
@@ -18,7 +18,7 @@ from typing import (
 from psygnal import Signal, SignalGroup
 
 if TYPE_CHECKING:
-    from typing import Self
+    from typing_extensions import Self
 
 
 _T = TypeVar("_T")

--- a/src/psygnal/containers/_evented_set.py
+++ b/src/psygnal/containers/_evented_set.py
@@ -218,7 +218,7 @@ class SetEvents(SignalGroup):
         added or removed from the set.
     """
 
-    items_changed = Signal(tuple, tuple, emission_strategy="sequential")
+    items_changed = Signal(tuple, tuple, reemission="queued")
 
 
 class EventedSet(_BaseMutableSet[_T]):

--- a/src/psygnal/containers/_evented_set.py
+++ b/src/psygnal/containers/_evented_set.py
@@ -218,7 +218,7 @@ class SetEvents(SignalGroup):
         added or removed from the set.
     """
 
-    items_changed = Signal(tuple, tuple, recursion_mode="deferred")
+    items_changed = Signal(tuple, tuple, emission_strategy="sequential")
 
 
 class EventedSet(_BaseMutableSet[_T]):

--- a/tests/test_psygnal.py
+++ b/tests/test_psygnal.py
@@ -11,6 +11,7 @@ import pytest
 
 import psygnal
 from psygnal import EmitLoopError, Signal, SignalInstance
+from psygnal._signal import RecursionMode
 from psygnal._weak_callback import WeakCallback
 
 PY39 = sys.version_info[:2] == (3, 9)
@@ -980,7 +981,7 @@ def test_pickle():
 
 @pytest.mark.skipif(PY39 and WINDOWS and COMPILED, reason="fails")
 @pytest.mark.parametrize("recursion", ["immediate", "deferred"])
-def test_recursion_error(recursion: Literal["immediate", "deferred"]) -> None:
+def test_recursion_error(recursion: RecursionMode) -> None:
     s = SignalInstance(recursion_mode=recursion)
 
     @s.connect
@@ -991,8 +992,8 @@ def test_recursion_error(recursion: Literal["immediate", "deferred"]) -> None:
         s.emit()
 
 
-@pytest.mark.parametrize("recursion", ["immediate", "deferred"])
-def test_callback_order(recursion: Literal["immediate", "deferred"]) -> None:
+@pytest.mark.parametrize("recursion", ["immediate", "deferred", "immediate-drop"])
+def test_callback_order(recursion: RecursionMode) -> None:
     sig = SignalInstance((int,), recursion_mode=recursion)
 
     a = []
@@ -1019,13 +1020,18 @@ def test_callback_order(recursion: Literal["immediate", "deferred"]) -> None:
         # nested emission events occur immediately,
         # before proceeding to the next callback
         assert a == [1, 2, 20, 3, 30, 300, 200, 10, 100]
+    elif recursion == "immediate-drop":
+        # nested emission events occur immediately,
+        # before proceeding to the next callback
+        # AND any remaining emissions in the current loop level are cancelled
+        assert a == [1, 2, 20, 3, 30, 300]
     elif recursion == "deferred":
         # all callbacks are called once before the next one is called
         assert a == [1, 10, 100, 2, 20, 200, 3, 30, 300]
 
 
 @pytest.mark.parametrize("recursion", ["immediate", "deferred"])
-def test_signal_order_suspend(recursion: Literal["immediate", "deferred"]) -> None:
+def test_signal_order_suspend(recursion: RecursionMode) -> None:
     """Test that signals are emitted in the order they were connected."""
     sig = SignalInstance((int,), recursion_mode=recursion)
     mock1 = Mock()


### PR DESCRIPTION
This PR renames the parameter controlling how callbacks are (re-)invoked when one of the callbacks itself emits the signal currently being emitted.  From the new docstrings:

```
reemission : Literal["immediate", "queued", "latest-only"] | None
    Determines the order and manner in which connected callbacks are invoked when a
    callback re-emits a signal. Default is `"immediate"`.
```

  * `"immediate"`: Signals emitted by callbacks are immediately processed in a
      deeper emission loop, before returning to process signals emitted at the
      current level (after all callbacks in the deeper level have been called).

  * `"queued"`: Signals emitted by callbacks are enqueued for emission after the
      current level of emission is complete. This ensures *all* connected
      callbacks are called with the first emitted value, before *any* of them are
      called with values emitted while calling callbacks.

  * `"latest-only"`: Signals emitted by callbacks are immediately processed in a
      deeper emission loop, and remaining callbacks in the current level are never
      called with the original value.

@Czaki, I was thinking this might actually be the desired behavior for evented models, since it not only makes sure that the current value is always up to date, it also prevents emitting things that are just about to become irrelevant