### PR TITLE
feat: add signal aliases on SignalGroup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## [v0.10.1](https://github.com/pyapp-kit/psygnal/tree/v0.10.1) (2024-03-11)
+
+[Full Changelog](https://github.com/pyapp-kit/psygnal/compare/v0.10.0...v0.10.1)
+
+**Implemented enhancements:**
+
+- feat: Add recursion\_mode \('immediate' or 'deferred'\) to Signal and SignalInstance [\#293](https://github.com/pyapp-kit/psygnal/pull/293) ([tlambert03](https://github.com/tlambert03))
+- feat: add collect\_fields option to SignalGroupDescriptor, and accept a SignalGroup subclass [\#291](https://github.com/pyapp-kit/psygnal/pull/291) ([getzze](https://github.com/getzze))
+
+**Merged pull requests:**
+
+- ci\(dependabot\): bump softprops/action-gh-release from 1 to 2 [\#295](https://github.com/pyapp-kit/psygnal/pull/295) ([dependabot[bot]](https://github.com/apps/dependabot))
+- chore: patch asv config to work locally with arm64 macos on hatchling [\#294](https://github.com/pyapp-kit/psygnal/pull/294) ([tlambert03](https://github.com/tlambert03))
+- A bit more consistent SignalGroup iter [\#289](https://github.com/pyapp-kit/psygnal/pull/289) ([getzze](https://github.com/getzze))
+
 ## [v0.10.0](https://github.com/pyapp-kit/psygnal/tree/v0.10.0) (2024-03-05)
 
 [Full Changelog](https://github.com/pyapp-kit/psygnal/compare/v0.9.5...v0.10.0)

--- a/src/psygnal/__init__.py
+++ b/src/psygnal/__init__.py
@@ -28,7 +28,6 @@ __all__ = [
     "evented",
     "EventedModel",
     "get_evented_namespace",
-    "get_signal_from_field",
     "is_evented",
     "Signal",
     "SignalGroup",
@@ -52,12 +51,7 @@ if os.getenv("PSYGNAL_UNCOMPILED"):
 from ._evented_decorator import evented
 from ._exceptions import EmitLoopError
 from ._group import EmissionInfo, SignalGroup
-from ._group_descriptor import (
-    SignalGroupDescriptor,
-    get_evented_namespace,
-    get_signal_from_field,
-    is_evented,
-)
+from ._group_descriptor import SignalGroupDescriptor, get_evented_namespace, is_evented
 from ._queue import emit_queued
 from ._signal import Signal, SignalInstance, _compiled
 from ._throttler import debounced, throttled

--- a/src/psygnal/__init__.py
+++ b/src/psygnal/__init__.py
@@ -28,6 +28,7 @@ __all__ = [
     "evented",
     "EventedModel",
     "get_evented_namespace",
+    "get_signal_from_field",
     "is_evented",
     "Signal",
     "SignalGroup",
@@ -54,6 +55,7 @@ from ._group import EmissionInfo, SignalGroup
 from ._group_descriptor import (
     SignalGroupDescriptor,
     get_evented_namespace,
+    get_signal_from_field,
     is_evented,
 )
 from ._queue import emit_queued

--- a/src/psygnal/_evented_decorator.py
+++ b/src/psygnal/_evented_decorator.py
@@ -1,14 +1,11 @@
 from __future__ import annotations
 
-from typing import (
-    Callable,
-    Literal,
-    Mapping,
-    TypeVar,
-    overload,
-)
+from typing import TYPE_CHECKING, Callable, Literal, Mapping, TypeVar, overload
 
-from psygnal._group_descriptor import EqOperator, FieldAliasFunc, SignalGroupDescriptor
+from psygnal._group_descriptor import SignalGroupDescriptor
+
+if TYPE_CHECKING:
+    from psygnal._group_descriptor import EqOperator, FieldAliasFunc
 
 __all__ = ["evented"]
 

--- a/src/psygnal/_evented_decorator.py
+++ b/src/psygnal/_evented_decorator.py
@@ -1,20 +1,18 @@
 from __future__ import annotations
 
 from typing import (
-    Any,
     Callable,
     Literal,
+    Mapping,
     TypeVar,
     overload,
 )
 
-from psygnal._group_descriptor import SignalGroupDescriptor
+from psygnal._group_descriptor import EqOperator, FieldAliasFunc, SignalGroupDescriptor
 
 __all__ = ["evented"]
 
 T = TypeVar("T", bound=type)
-
-EqOperator = Callable[[Any, Any], bool]
 
 
 @overload
@@ -25,6 +23,7 @@ def evented(
     equality_operators: dict[str, EqOperator] | None = None,
     warn_on_no_fields: bool = ...,
     cache_on_instance: bool = ...,
+    signal_aliases: Mapping[str, str | None] | FieldAliasFunc | None = ...,
 ) -> T: ...
 
 
@@ -36,6 +35,7 @@ def evented(
     equality_operators: dict[str, EqOperator] | None = None,
     warn_on_no_fields: bool = ...,
     cache_on_instance: bool = ...,
+    signal_aliases: Mapping[str, str | None] | FieldAliasFunc | None = ...,
 ) -> Callable[[T], T]: ...
 
 
@@ -46,6 +46,7 @@ def evented(
     equality_operators: dict[str, EqOperator] | None = None,
     warn_on_no_fields: bool = True,
     cache_on_instance: bool = True,
+    signal_aliases: Mapping[str, str | None] | FieldAliasFunc | None = None,
 ) -> Callable[[T], T] | T:
     """A decorator to add events to a dataclass.
 
@@ -85,6 +86,14 @@ def evented(
         access, but means that the owner instance will no longer be pickleable.  If
         `False`, the SignalGroup instance will *still* be cached, but not on the
         instance itself.
+    signal_aliases: Mapping[str, str | None] | Callable[[str], str | None] | None
+        If defined, a mapping between field name and signal name. Field names that are
+        not `signal_aliases` keys are not aliased (the signal name is the field name).
+        If the dict value is None, do not create a signal associated with this field.
+        If a callable, the signal name is the output of the function applied to the
+        field name. If the output is None, no signal is created for this field.
+        If None, defaults to an empty dict, no aliases.
+        Default to None
 
     Returns
     -------
@@ -122,6 +131,7 @@ def evented(
             equality_operators=equality_operators,
             warn_on_no_fields=warn_on_no_fields,
             cache_on_instance=cache_on_instance,
+            signal_aliases=signal_aliases,
         )
         # as a decorator, this will have already been called
         descriptor.__set_name__(cls, events_namespace)

--- a/src/psygnal/_group.py
+++ b/src/psygnal/_group.py
@@ -260,6 +260,7 @@ class SignalGroup:
     _psygnal_signals: ClassVar[Mapping[str, Signal]]
     _psygnal_uniform: ClassVar[bool] = False
     _psygnal_name_conflicts: ClassVar[set[str]]
+    _psygnal_aliases: ClassVar[Mapping[str, str | None]]
 
     _psygnal_instances: dict[str, SignalInstance]
 
@@ -280,7 +281,11 @@ class SignalGroup:
         }
         self._psygnal_relay = SignalRelay(self._psygnal_instances, instance)
 
-    def __init_subclass__(cls, strict: bool = False) -> None:
+    def __init_subclass__(
+        cls,
+        strict: bool = False,
+        signal_aliases: Mapping[str, str | None] = {},
+    ) -> None:
         """Collects all Signal instances on the class under `cls._psygnal_signals`."""
         # Collect Signals and remove from class attributes
         # Use dir(cls) instead of cls.__dict__ to get attributes from super()
@@ -327,6 +332,9 @@ class SignalGroup:
                 UserWarning,
                 stacklevel=2,
             )
+
+        aliases = getattr(cls, "_psygnal_aliases", {})
+        cls._psygnal_aliases = {**aliases, **signal_aliases}
 
         cls._psygnal_uniform = _is_uniform(cls._psygnal_signals.values())
         if strict and not cls._psygnal_uniform:
@@ -402,6 +410,12 @@ class SignalGroup:
         """Return repr(self)."""
         name = self.__class__.__name__
         return f"<SignalGroup {name!r} with {len(self)} signals>"
+
+    def get_signal_by_alias(self, name: str) -> SignalInstance | None:
+        sig_name = self._psygnal_aliases.get(name, name)
+        if sig_name is None or sig_name not in self:
+            return None
+        return self[sig_name]
 
     @classmethod
     def psygnals_uniform(cls) -> bool:

--- a/src/psygnal/_group.py
+++ b/src/psygnal/_group.py
@@ -410,12 +410,6 @@ class SignalGroup:
         name = self.__class__.__name__
         return f"<SignalGroup {name!r} with {len(self)} signals>"
 
-    def get_signal_by_alias(self, name: str) -> SignalInstance | None:
-        sig_name = self._psygnal_aliases.get(name, name)
-        if sig_name is None or sig_name not in self:
-            return None
-        return self[sig_name]
-
     @classmethod
     def psygnals_uniform(cls) -> bool:
         """Return true if all signals in the group have the same signature."""

--- a/src/psygnal/_group.py
+++ b/src/psygnal/_group.py
@@ -335,7 +335,6 @@ class SignalGroup:
 
         aliases = getattr(cls, "_psygnal_aliases", {})
         cls._psygnal_aliases = {**aliases, **signal_aliases}
-
         cls._psygnal_uniform = _is_uniform(cls._psygnal_signals.values())
         if strict and not cls._psygnal_uniform:
             raise TypeError(

--- a/src/psygnal/_group.py
+++ b/src/psygnal/_group.py
@@ -260,7 +260,7 @@ class SignalGroup:
     _psygnal_signals: ClassVar[Mapping[str, Signal]]
     _psygnal_uniform: ClassVar[bool] = False
     _psygnal_name_conflicts: ClassVar[set[str]]
-    _psygnal_aliases: ClassVar[Mapping[str, str | None]]
+    _psygnal_aliases: ClassVar[dict[str, str | None]]
 
     _psygnal_instances: dict[str, SignalInstance]
 

--- a/src/psygnal/_group_descriptor.py
+++ b/src/psygnal/_group_descriptor.py
@@ -14,6 +14,7 @@ from typing import (
     Iterable,
     Literal,
     Mapping,
+    Optional,
     Type,
     TypeVar,
     cast,
@@ -31,7 +32,7 @@ if TYPE_CHECKING:
     from psygnal._weak_callback import RefErrorChoice, WeakCallback
 
     EqOperator: TypeAlias = Callable[[Any, Any], bool]
-    FieldAliasFunc: TypeAlias = Callable[[str], str | None]
+    FieldAliasFunc: TypeAlias = Callable[[str], Optional[str]]
 
 __all__ = ["is_evented", "get_evented_namespace", "SignalGroupDescriptor"]
 

--- a/src/psygnal/_group_descriptor.py
+++ b/src/psygnal/_group_descriptor.py
@@ -150,10 +150,6 @@ class _DataclassFieldSignalInstance(SignalInstance):
         )
 
 
-def _identity(x: str) -> str:
-    return x
-
-
 def _build_dataclass_signal_group(
     cls: type,
     signal_group_class: type[SignalGroup],

--- a/src/psygnal/_group_descriptor.py
+++ b/src/psygnal/_group_descriptor.py
@@ -14,6 +14,7 @@ from typing import (
     Iterable,
     Literal,
     Mapping,
+    Optional,
     Type,
     TypeVar,
     cast,
@@ -39,7 +40,7 @@ __all__ = [
 ]
 
 EqOperator = Callable[[Any, Any], bool]
-FieldAliasFunc = Callable[[str], str | None]
+FieldAliasFunc = Callable[[str], Optional[str]]
 T = TypeVar("T", bound=Type)
 S = TypeVar("S")
 
@@ -357,7 +358,7 @@ def evented_setattr(
 
             group: SignalGroup | None = getattr(self, signal_group_name, None)
             if not isinstance(group, SignalGroup):
-                return super_setattr(self, name, value)
+                return super_setattr(self, name, value)  # pragma: no cover
 
             # don't emit if the signal doesn't exist or has no listeners
             signal: SignalInstance | None = group.get_signal_by_alias(name)
@@ -586,7 +587,7 @@ class SignalGroupDescriptor:
 
             # Add aliases
             if callable(self._signal_aliases):
-                warnings.warn(
+                warnings.warn(  # pragma: no cover
                     "Skip signal aliases, cannot use a callable `signal_aliases` with "
                     "`collect_fields=False`",
                     UserWarning,

--- a/src/psygnal/_group_descriptor.py
+++ b/src/psygnal/_group_descriptor.py
@@ -26,11 +26,12 @@ from ._signal import Signal, SignalInstance
 
 if TYPE_CHECKING:
     from _weakref import ref as ref
+    from typing_extensions import TypeAlias
 
     from psygnal._weak_callback import RefErrorChoice, WeakCallback
 
-    EqOperator = Callable[[Any, Any], bool]
-    FieldAliasFunc = Callable[[str], str | None]
+    EqOperator: TypeAlias = Callable[[Any, Any], bool]
+    FieldAliasFunc: TypeAlias = Callable[[str], str | None]
 
 __all__ = ["is_evented", "get_evented_namespace", "SignalGroupDescriptor"]
 

--- a/src/psygnal/_group_descriptor.py
+++ b/src/psygnal/_group_descriptor.py
@@ -243,7 +243,7 @@ def _build_dataclass_signal_group(
         # patch in our custom SignalInstance class with maxargs=1 on connect_setattr
         sig._signal_instance_class = _DataclassFieldSignalInstance
 
-    # Create SignalGroup subclass with the attached signals and signal_aliases
+    # Create `signal_group_class` subclass with the attached signals and signal_aliases
     return type(
         group_name, (signal_group_class,), signals, signal_aliases=_signal_aliases
     )
@@ -434,7 +434,7 @@ class SignalGroupDescriptor:
         events when fields change.  If `False`, no `__setattr__` method will be
         created.  (This will prevent signal emission, and assumes you are using a
         different mechanism to emit signals when fields change.)
-    signal_group_class : type[SignalGroup] | None, optionalq
+    signal_group_class : type[SignalGroup] | None, optional
         A custom SignalGroup class to use, SignalGroup if None, by default None
     collect_fields : bool, optional
         Create a signal for each field in the dataclass. If True, the `SignalGroup`
@@ -589,12 +589,8 @@ class SignalGroupDescriptor:
                     UserWarning,
                     stacklevel=2,
                 )
-                Group._psygnal_aliases = {}
             elif isinstance(self._signal_aliases, dict):
-                Group._psygnal_aliases = {
-                    **Group._psygnal_aliases,
-                    **self._signal_aliases,
-                }
+                Group._psygnal_aliases.update(self._signal_aliases)
 
         # Collect fields and create SignalGroup subclass
         else:

--- a/tests/test_evented_model.py
+++ b/tests/test_evented_model.py
@@ -70,7 +70,6 @@ def test_evented_model():
 
     # test event system
     assert isinstance(user.events, SignalGroup)
-    # with pytest.warns(FutureWarning):
     assert "id" in user.events
     assert "name" in user.events
 

--- a/tests/test_evented_model.py
+++ b/tests/test_evented_model.py
@@ -71,8 +71,8 @@ def test_evented_model():
     # test event system
     assert isinstance(user.events, SignalGroup)
     # with pytest.warns(FutureWarning):
-    assert "id" in user.events.signals
-    assert "name" in user.events.signals
+    assert "id" in user.events
+    assert "name" in user.events
 
     # ClassVars are excluded from events
     assert "age" not in user.events

--- a/tests/test_group.py
+++ b/tests/test_group.py
@@ -121,7 +121,7 @@ def test_signal_group_connect_no_args() -> None:
     def my_slot() -> None:
         count.append(1)
 
-    group.all.connect(my_slot)
+    group.connect(my_slot)
     group.sig1.emit(1)
     group.sig2.emit("hi")
     assert len(count) == 2
@@ -133,7 +133,7 @@ def test_group_blocked() -> None:
     mock1 = Mock()
     mock2 = Mock()
 
-    group.all.connect(mock1)
+    group.connect(mock1)
     group.sig1.connect(mock2)
     group.sig1.emit(1)
 
@@ -185,7 +185,7 @@ def test_group_disconnect_single_slot() -> None:
     group.sig1.connect(mock1)
     group.sig2.connect(mock2)
 
-    group.all.disconnect(mock1)
+    group.disconnect(mock1)
     group.sig1.emit()
     mock1.assert_not_called()
 
@@ -203,7 +203,7 @@ def test_group_disconnect_all_slots() -> None:
     group.sig1.connect(mock1)
     group.sig2.connect(mock2)
 
-    group.all.disconnect()
+    group.disconnect()
     group.sig1.emit()
     group.sig2.emit()
 
@@ -259,14 +259,14 @@ def test_group_deepcopy(
     group = Group(obj)
     assert deepcopy(group) is not group  # but no warning
 
-    group.all.connect(obj.method)
+    group.connect(obj.method)
     group2 = deepcopy(group)
 
     assert not len(group2.all)
     mock = Mock()
     mock2 = Mock()
-    group.all.connect(mock)
-    group2.all.connect(mock2)
+    group.connect(mock)
+    group2.connect(mock2)
 
     # test that we can access signalinstances (either using getattr or __getitem__)
     siginst1 = get_sig(group, signame)

--- a/tests/test_group.py
+++ b/tests/test_group.py
@@ -44,6 +44,7 @@ def test_signal_group() -> None:
     assert not group.psygnals_uniform()
     assert list(group) == ["sig1", "sig2"]  # testing __iter__
     assert group.sig1 is group["sig1"]
+    assert set(group.signals) == {"sig1", "sig2"}
 
     assert repr(group) == "<SignalGroup 'MyGroup' with 2 signals>"
 

--- a/tests/test_group_aliases.py
+++ b/tests/test_group_aliases.py
@@ -392,3 +392,27 @@ def test_direct_signal_group() -> None:
     foo._e = 6
     mock.assert_called_once_with(6, 5)
     mock.reset_mock()
+
+
+def test_bad_siggroup_descriptor_init():
+    with pytest.raises(
+        TypeError,
+        match="'signal_group_class' must be a subclass of SignalGroup",
+    ):
+        SignalGroupDescriptor(signal_group_class=type)  # type: ignore
+
+    with pytest.raises(
+        ValueError,
+        match="Cannot use SignalGroup with `collect_fields=False`.",
+    ):
+        SignalGroupDescriptor(collect_fields=False)
+
+    with pytest.raises(
+        ValueError,
+        match="Cannot use a Callable for `signal_aliases` with `collect_fields=False`",
+    ):
+        SignalGroupDescriptor(
+            collect_fields=False,
+            signal_group_class=type("MyGroup", (SignalGroup,), {"x": Signal()}),
+            signal_aliases=lambda x: None,
+        )

--- a/tests/test_group_aliases.py
+++ b/tests/test_group_aliases.py
@@ -1,0 +1,299 @@
+# from __future__ import annotations  # breaks msgspec Annotated
+
+from typing import ClassVar
+from unittest.mock import Mock
+
+import pytest
+
+from psygnal import (
+    Signal,
+    SignalGroup,
+    SignalGroupDescriptor,
+)
+
+
+@pytest.mark.parametrize(
+    "type_",
+    [
+        "dataclass",
+        "attrs",
+        "pydantic",
+        "msgspec",
+    ],
+)
+def test_alias_parameters(type_: str) -> None:
+    foo_options = {"signal_aliases": {"_b": None}}
+    bar_options = {
+        "signal_aliases": lambda x: None if x.startswith("_") else f"{x}_changed"
+    }
+    baz_options = {"signal_aliases": {"a": "a_changed", "_b": "b_changed"}}
+
+    if type_ == "dataclass":
+        from dataclasses import dataclass, field
+
+        @dataclass
+        class Foo:
+            events: ClassVar = SignalGroupDescriptor(**foo_options)
+            a: int
+            _b: str
+
+        @dataclass
+        class Bar:
+            events: ClassVar = SignalGroupDescriptor(**bar_options)
+            a: int
+            _b: str
+
+        @dataclass
+        class Baz:
+            events: ClassVar = SignalGroupDescriptor(**baz_options)
+            a: int
+            _b: str = field(default="b")
+
+            @property
+            def b(self) -> str:
+                return self._b
+
+            @b.setter
+            def b(self, value: str):
+                self._b = value
+
+    elif type_ == "attrs":
+        from attrs import define, field
+
+        @define
+        class Foo:
+            events: ClassVar = SignalGroupDescriptor(**foo_options)
+            a: int
+            _b: str = field(alias="_b")
+
+        @define
+        class Bar:
+            events: ClassVar = SignalGroupDescriptor(**bar_options)
+            a: int
+            _b: str = field(alias="_b")
+
+        @define
+        class Baz:
+            events: ClassVar = SignalGroupDescriptor(**baz_options)
+            a: int
+            _b: str = field(alias="_b", default="b")
+
+            @property
+            def b(self) -> str:
+                return self._b
+
+            @b.setter
+            def b(self, value: str):
+                self._b = value
+
+    elif type_ == "pydantic":
+        pytest.importorskip("pydantic", minversion="2")
+        from pydantic import BaseModel
+
+        class Foo(BaseModel):
+            events: ClassVar = SignalGroupDescriptor(**foo_options)
+            a: int
+            _b: str  # not a field anyway
+
+        class Bar(BaseModel):
+            events: ClassVar = SignalGroupDescriptor(**bar_options)
+            a: int
+            _b: str  # not a field anyway
+
+        class Baz(BaseModel):
+            events: ClassVar = SignalGroupDescriptor(**baz_options)
+            a: int
+            _b: str = "b"  # not defining a field, signal will not be created
+
+            @property
+            def b(self) -> str:
+                return self._b
+
+            @b.setter
+            def b(self, value: str):
+                self._b = value
+
+    elif type_ == "msgspec":
+        msgspec = pytest.importorskip("msgspec")
+
+        class Foo(msgspec.Struct):  # type: ignore
+            events: ClassVar = SignalGroupDescriptor(**foo_options)
+            a: int
+            _b: str
+
+        class Bar(msgspec.Struct):  # type: ignore
+            events: ClassVar = SignalGroupDescriptor(**bar_options)
+            a: int
+            _b: str
+
+        class Baz(msgspec.Struct):  # type: ignore
+            events: ClassVar = SignalGroupDescriptor(**baz_options)
+            a: int
+            _b: str = "b"
+
+            @property
+            def b(self) -> str:
+                return self._b
+
+            @b.setter
+            def b(self, value: str):
+                self._b = value
+
+    # Instantiate objects
+    foo = Foo(a=1, _b="b")
+    bar = Bar(a=1, _b="b")
+    baz = Baz(a=1)
+
+    # Check signals
+    assert set(foo.events) == {"a"}
+    assert hasattr(foo.events, "_psygnal_aliases")
+    assert foo.events._psygnal_aliases == {"a": "a", "_b": None}
+
+    assert set(bar.events) == {"a_changed"}
+    assert hasattr(bar.events, "_psygnal_aliases")
+    if type_.startswith("pydantic"):
+        assert bar.events._psygnal_aliases == {"a": "a_changed"}
+    else:
+        assert bar.events._psygnal_aliases == {"a": "a_changed", "_b": None}
+
+    if type_.startswith("pydantic"):
+        assert set(baz.events) == {"a_changed"}
+    else:
+        assert set(baz.events) == {"a_changed", "b_changed"}
+    assert hasattr(baz.events, "_psygnal_aliases")
+    assert baz.events._psygnal_aliases == {
+        "a": "a_changed",
+        "_b": "b_changed",
+    }
+
+    mock = Mock()
+    foo.events.a.connect(mock)
+    bar.events.a_changed.connect(mock)
+    baz.events.a_changed.connect(mock)
+    if not type_.startswith("pydantic"):
+        baz.events.b_changed.connect(mock)
+
+    # Foo
+    foo.a = 1
+    mock.assert_not_called()
+    foo.a = 2
+    mock.assert_called_once_with(2, 1)
+    mock.reset_mock()
+    foo._b = "b"
+    foo._b = "c"
+    mock.assert_not_called()
+
+    # Bar
+    bar.a = 1
+    mock.assert_not_called()
+    bar.a = 2
+    mock.assert_called_once_with(2, 1)
+    mock.reset_mock()
+    bar._b = "b"
+    bar._b = "c"
+    mock.assert_not_called()
+
+    # Baz
+    baz.a = 1
+    mock.assert_not_called()
+    baz.a = 2
+    mock.assert_called_once_with(2, 1)
+    mock.reset_mock()
+
+    # pydantic v1 does not support properties
+    if type_ == "pydantic_v1":
+        return
+
+    baz.b = "b"
+    mock.assert_not_called()
+    baz.b = "c"
+    if not type_.startswith("pydantic"):
+        mock.assert_called_once_with("c", "b")
+
+
+@pytest.mark.parametrize("collect", [False, True])
+def test_direct_signal_group(collect) -> None:
+
+    class FooSignalGroup(SignalGroup, signal_aliases={"e": None}):
+        a = Signal(int, int)
+        b_changed = Signal(float, float)
+        c = Signal(str, str)
+        d = Signal(str, str)
+        e = Signal(str, str)
+
+    class Foo:
+        events: ClassVar = SignalGroupDescriptor(
+            signal_group_class=FooSignalGroup,
+            collect_fields=collect,
+            signal_aliases={"b": "b_changed", "c": None, "_c": "c"},
+        )
+        a: int
+        b: float
+        _c: str
+        _d: str
+
+        def __init__(self, a: int = 1, b: float = 2.0, c: str = "c", d: str = "d"):
+            self.a = a
+            self.b = b
+            self.c = c
+            self.d = d
+
+        @property
+        def c(self) -> str:
+            return self._c
+
+        @c.setter
+        def c(self, value: str):
+            self._c = value
+
+        @property
+        def d(self) -> str:
+            return self._d.lower()
+
+        @d.setter
+        def d(self, value: str):
+            self._d = value
+
+    foo = Foo()
+
+    assert hasattr(foo.events, "_psygnal_aliases")
+    assert foo.events._psygnal_aliases == {
+        'b': 'b_changed',
+        '_c': 'c',
+        'c': None,
+        'e': None,
+    }
+
+    mock = Mock()
+    foo.events.a.connect(mock)
+    foo.events.b_changed.connect(mock)
+    foo.events.c.connect(mock)
+    foo.events.d.connect(mock)
+
+    foo.events.e.connect(mock)
+    foo.events.e.emit("f", "e")
+    mock.assert_called_once_with("f", "e")
+    mock.reset_mock()
+
+    foo.a = 2
+    mock.assert_called_once_with(2, 1)
+    mock.reset_mock()
+
+    foo.b = 3.0
+    mock.assert_called_once_with(3.0, 2.0)
+    mock.reset_mock()
+
+    foo.c = "c"
+    mock.assert_not_called()
+    foo.c = "cc"
+    mock.assert_called_once_with("cc", "c")
+    mock.reset_mock()
+    foo._c = "ccc"
+    mock.assert_called_once_with("ccc", "cc")
+    mock.reset_mock()
+
+    foo.d = "D"
+    mock.assert_not_called()
+    foo.d = "DD"
+    mock.assert_called_once_with("dd", "d")
+    mock.reset_mock()

--- a/tests/test_group_aliases.py
+++ b/tests/test_group_aliases.py
@@ -22,11 +22,9 @@ from psygnal import (
     ],
 )
 def test_alias_parameters(type_: str) -> None:
-
     class MyGroup(SignalGroup, signal_aliases={"b": None, "bb": None}):
         b = Signal(str, str)
         bb = Signal(str, str)
-
 
     foo_options = {"signal_aliases": {"_b": None}}
     bar_options = {
@@ -34,9 +32,9 @@ def test_alias_parameters(type_: str) -> None:
     }
     baz_options = {"signal_aliases": {"a": "a_changed", "_b": "b_changed"}}
     baz2_options = {
-        "signal_group_class": MyGroup, "signal_aliases": {"aa": "a", "bb": "b"}
+        "signal_group_class": MyGroup,
+        "signal_aliases": {"aa": "a", "bb": "b"},
     }
-
 
     if type_ == "dataclass":
         from dataclasses import dataclass, field
@@ -75,7 +73,6 @@ def test_alias_parameters(type_: str) -> None:
             b: str
             bb: str
 
-
     elif type_ == "attrs":
         from attrs import define, field
 
@@ -113,7 +110,6 @@ def test_alias_parameters(type_: str) -> None:
             b: str
             bb: str
 
-
     elif type_ == "pydantic":
         pytest.importorskip("pydantic", minversion="2")
         from pydantic import BaseModel
@@ -148,7 +144,6 @@ def test_alias_parameters(type_: str) -> None:
             b: str
             bb: str
 
-
     elif type_ == "msgspec":
         msgspec = pytest.importorskip("msgspec")
 
@@ -182,7 +177,6 @@ def test_alias_parameters(type_: str) -> None:
             b: str
             bb: str
 
-
     # Instantiate objects
     foo = Foo(a=1, _b="b")
     bar = Bar(a=1, _b="b")
@@ -215,12 +209,8 @@ def test_alias_parameters(type_: str) -> None:
     with pytest.warns(UserWarning) as record:
         assert set(baz2.events) == {"a", "b", "bb"}
     assert len(record) == 2
-    assert record[0].message.args[0].startswith(
-        "Skip signal \'a\', was already created"
-    )
-    assert record[1].message.args[0].startswith(
-        "Skip signal \'b\', was already defined"
-    )
+    assert record[0].message.args[0].startswith("Skip signal 'a', was already created")
+    assert record[1].message.args[0].startswith("Skip signal 'b', was already defined")
     assert hasattr(baz.events, "_psygnal_aliases")
     assert baz2.events._psygnal_aliases == {
         "a": "a",
@@ -298,7 +288,6 @@ def test_alias_parameters(type_: str) -> None:
 
 
 def test_direct_signal_group() -> None:
-
     class FooSignalGroup(SignalGroup, signal_aliases={"e": None}):
         a = Signal(int, int)
         b_changed = Signal(float, float)
@@ -357,11 +346,11 @@ def test_direct_signal_group() -> None:
 
     assert hasattr(foo.events, "_psygnal_aliases")
     assert foo.events._psygnal_aliases == {
-        'b': 'b_changed',
-        '_c': 'c',
-        'c': None,
-        'e': None,
-        '_e': 'e',
+        "b": "b_changed",
+        "_c": "c",
+        "c": None,
+        "e": None,
+        "_e": "e",
     }
 
     mock = Mock()

--- a/tests/test_group_aliases.py
+++ b/tests/test_group_aliases.py
@@ -22,7 +22,9 @@ from psygnal import (
     ],
 )
 def test_alias_parameters(type_: str) -> None:
-    class MyGroup(SignalGroup, signal_aliases={"b": None, "bb": None}):
+    root_aliases = {"b": None, "bb": None}
+
+    class MyGroup(SignalGroup, signal_aliases=root_aliases):
         b = Signal(str, str)
         bb = Signal(str, str)
 
@@ -186,7 +188,7 @@ def test_alias_parameters(type_: str) -> None:
     # Check signals
     assert set(foo.events) == {"a"}
     assert hasattr(foo.events, "_psygnal_aliases")
-    assert foo.events._psygnal_aliases == {"a": "a", "_b": None}
+    assert foo.events._psygnal_aliases == foo_options["signal_aliases"]
 
     assert set(bar.events) == {"a_changed"}
     assert hasattr(bar.events, "_psygnal_aliases")
@@ -200,10 +202,7 @@ def test_alias_parameters(type_: str) -> None:
     else:
         assert set(baz.events) == {"a_changed", "b_changed"}
     assert hasattr(baz.events, "_psygnal_aliases")
-    assert baz.events._psygnal_aliases == {
-        "a": "a_changed",
-        "_b": "b_changed",
-    }
+    assert baz.events._psygnal_aliases == baz_options["signal_aliases"]
 
     # with pytest.warns(UserWarning, match=r"Skip signal \'a\', was already created"):
     with pytest.warns(UserWarning) as record:
@@ -213,10 +212,8 @@ def test_alias_parameters(type_: str) -> None:
     assert record[1].message.args[0].startswith("Skip signal 'b', was already defined")
     assert hasattr(baz.events, "_psygnal_aliases")
     assert baz2.events._psygnal_aliases == {
-        "a": "a",
-        "aa": "a",
-        "b": None,
-        "bb": "b",
+        **root_aliases,
+        **baz2_options["signal_aliases"],
     }
 
     mock = Mock()


### PR DESCRIPTION
Split from #265
solves https://github.com/pyapp-kit/psygnal/issues/261

Add a keyword argument to `SignalGroupDescriptor` to specify signal aliases (if the alias is None, no signal is created for this field). The signal aliases table is stored in the `SignalGroup` class (or subclass).

