### PR TITLE
fix: fix hard reference to objects in emitted arguments

### DIFF
--- a/src/psygnal/_exceptions.py
+++ b/src/psygnal/_exceptions.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Callable
+from typing import TYPE_CHECKING, Any, Callable
 
 from ._weak_callback import WeakCallback
 
@@ -19,13 +19,13 @@ class EmitLoopError(Exception):
 
     def __init__(
         self,
-        cb: WeakCallback | Callable,
-        args: tuple,
+        cb: WeakCallback | Callable | None,
+        args: tuple[Any, ...] | None,
         exc: BaseException,
         signal: SignalInstance | None = None,
     ) -> None:
         self.exc = exc
-        self.args = args
+        self.args = args or ()
         self.__cause__ = exc  # mypyc doesn't set this, but uncompiled code would
         if signal is None:
             sig_name = ""

--- a/tests/test_psygnal.py
+++ b/tests/test_psygnal.py
@@ -1090,3 +1090,23 @@ def test_slotted_classes() -> None:
     mock.assert_called_once()
 
     assert t.sig is t.sig
+
+
+def test_emit_should_not_prevent_gc():
+    from weakref import WeakSet
+
+    from psygnal import Signal
+
+    class Obj:
+        pass
+
+    class SomethingWithSignal:
+        changed = Signal(object)
+
+    object_instances: WeakSet[Obj] = WeakSet()
+    something = SomethingWithSignal()
+    obj = Obj()
+    object_instances.add(obj)
+    something.changed.emit(obj)
+    del obj
+    assert len(object_instances) == 0


### PR DESCRIPTION
fixes #300 

I'm working on a better fix that would avoiding holding even a temporary pointer to the arguments, but want to get this fix out asap