### PR TITLE
refactor: change EmitLoopError message, and mechanism of info gathering

### DIFF
--- a/src/psygnal/_exceptions.py
+++ b/src/psygnal/_exceptions.py
@@ -1,47 +1,47 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Callable
-
-from ._weak_callback import WeakCallback
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from ._signal import SignalInstance
-
-MSG = """
-While emitting signal {sig!r}, an error occurred in callback {cb!r}.
-The args passed to the callback were: {args!r}
-This is not a bug in psygnal.  See {err!r} above for details.
-"""
 
 
 class EmitLoopError(Exception):
     """Error type raised when an exception occurs during a callback."""
 
+    __module__ = "psygnal"
+
     def __init__(
         self,
-        cb: WeakCallback | Callable | None,
-        args: tuple[Any, ...] | None,
         exc: BaseException,
         signal: SignalInstance | None = None,
     ) -> None:
-        self.exc = exc
-        self.args = args or ()
         self.__cause__ = exc  # mypyc doesn't set this, but uncompiled code would
+
         if signal is None:
             sig_name = ""
         else:
-            inst_class = signal.instance.__class__
-            mod = getattr(inst_class, "__module__", "")
-            sig_name = f"{mod}.{inst_class.__qualname__}.{signal.name}"
-        if isinstance(cb, WeakCallback):
-            cb_name = cb.slot_repr()
-        else:
-            cb_name = getattr(cb, "__qualname__", repr(cb))
-        super().__init__(
-            MSG.format(
-                sig=sig_name,
-                cb=cb_name,
-                args=args,
-                err=exc.__class__.__name__,
-            )
-        )
+            if instsance := signal.instance:
+                inst_class = instsance.__class__
+                mod = getattr(inst_class, "__module__", "")
+                if mod:
+                    mod += "."
+                sig_name = f"{mod}{inst_class.__qualname__}.{signal.name}"
+            else:
+                sig_name = repr(signal)
+
+        msg = f"\n\nWhile emitting signal {sig_name!r}, an error occurred in a callback"
+        if tb := exc.__traceback__:
+            while tb and tb.tb_next is not None:
+                tb = tb.tb_next
+            frame = tb.tb_frame
+            filename = frame.f_code.co_filename
+            func_name = getattr(frame.f_code, "co_qualname", frame.f_code.co_name)
+            msg += f":\n  File {filename}:{frame.f_lineno}, in {func_name}\n"
+            if frame.f_locals:
+                msg += "  With local variables:\n"
+                for name, value in frame.f_locals.items():
+                    msg += f"    {name} = {value!r}\n"
+
+        msg += f"\nSee {exc.__class__.__name__} above for details."
+        super().__init__(msg)

--- a/src/psygnal/_exceptions.py
+++ b/src/psygnal/_exceptions.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 import inspect
 from contextlib import suppress
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from textwrap import wrap
+from typing import TYPE_CHECKING, Any, Sequence
 
 import psygnal
 
@@ -23,7 +24,14 @@ class EmitLoopError(Exception):
         self,
         exc: BaseException,
         signal: SignalInstance | None = None,
+        recursion_depth: int = 0,
+        reemission: str | None = None,
+        emit_queue: Sequence[tuple] = (),
     ) -> None:
+        # if isinstance(exc, EmitLoopError):
+        #     super().__init__("nested EmitLoopError.")
+        #     return
+
         self.__cause__ = exc
 
         # grab the signal name or repr
@@ -43,6 +51,14 @@ class EmitLoopError(Exception):
         msg = (
             f"\n\nWhile emitting signal {sig_name!r}, a {etype} occurred in a callback"
         )
+        if recursion_depth:
+            s = "s" if recursion_depth > 1 else ""
+            msg += f"\nnested {recursion_depth} level{s} deep."
+            msg += (
+                "\n(A callback triggered by a signal"
+                + ", emitted by a signal" * recursion_depth
+                + ")"
+            )
         if tb := exc.__traceback__:
             msg += ":\n"
 
@@ -65,5 +81,21 @@ class EmitLoopError(Exception):
                         if name not in ("self", "cls"):
                             msg += f"       {name} = {value!r}\n"
 
+        # queued emission can be confusing, because the `signal.emit()` call shown
+        # in the traceback will not match the emission that actually raised the error.
+        if reemission == "queued" and (depth := len(emit_queue) - 1):
+            msg += (
+                "\nNOTE: reemission is set to 'queued', and this error occurred "
+                f"at a queue-depth of {depth}.\n"
+            )
+            emitted_by = wrap(
+                f"(A callback triggered by a signal{', emitted by a signal' * (depth)}"
+                f"... with arguments: {emit_queue[-1]})",
+                width=86,
+            )
+            msg += "\n".join(emitted_by)
+            msg += "\n"
+
         msg += f"\nSee {etype} above for original traceback."
+
         super().__init__(msg)

--- a/src/psygnal/_exceptions.py
+++ b/src/psygnal/_exceptions.py
@@ -18,7 +18,7 @@ class EmitLoopError(Exception):
     ) -> None:
         self.__cause__ = exc  # mypyc doesn't set this, but uncompiled code would
 
-        if signal is None:
+        if signal is None:  # pragma: no cover
             sig_name = ""
         else:
             if instsance := signal.instance:

--- a/src/psygnal/_exceptions.py
+++ b/src/psygnal/_exceptions.py
@@ -1,9 +1,17 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+import inspect
+from contextlib import suppress
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import psygnal
 
 if TYPE_CHECKING:
     from ._signal import SignalInstance
+
+
+ROOT = str(Path(psygnal.__file__).parent)
 
 
 class EmitLoopError(Exception):
@@ -16,10 +24,11 @@ class EmitLoopError(Exception):
         exc: BaseException,
         signal: SignalInstance | None = None,
     ) -> None:
-        self.__cause__ = exc  # mypyc doesn't set this, but uncompiled code would
+        self.__cause__ = exc
 
+        # grab the signal name or repr
         if signal is None:  # pragma: no cover
-            sig_name = ""
+            sig_name: Any = ""
         else:
             if instsance := signal.instance:
                 inst_class = instsance.__class__
@@ -28,20 +37,33 @@ class EmitLoopError(Exception):
                     mod += "."
                 sig_name = f"{mod}{inst_class.__qualname__}.{signal.name}"
             else:
-                sig_name = repr(signal)
+                sig_name = signal
 
-        msg = f"\n\nWhile emitting signal {sig_name!r}, an error occurred in a callback"
+        etype = exc.__class__.__name__  # name of the exception raised by callback.
+        msg = (
+            f"\n\nWhile emitting signal {sig_name!r}, a {etype} occurred in a callback"
+        )
         if tb := exc.__traceback__:
-            while tb and tb.tb_next is not None:
-                tb = tb.tb_next
-            frame = tb.tb_frame
-            filename = frame.f_code.co_filename
-            func_name = getattr(frame.f_code, "co_qualname", frame.f_code.co_name)
-            msg += f":\n  File {filename}:{frame.f_lineno}, in {func_name}\n"
-            if frame.f_locals:
-                msg += "  With local variables:\n"
-                for name, value in frame.f_locals.items():
-                    msg += f"    {name} = {value!r}\n"
+            msg += ":\n"
 
-        msg += f"\nSee {exc.__class__.__name__} above for details."
+            # get the first frame in the stack that is not in the psygnal package
+            with suppress(Exception):
+                fi = next(fi for fi in inspect.stack() if ROOT not in fi.filename)
+                msg += f"\n  Signal emitted at: {fi.filename}:{fi.lineno}, in {fi.function}\n"  # noqa: E501
+                if fi.code_context:
+                    msg += f"    >  {fi.code_context[0].strip()}\n"
+
+            # get the last frame in the traceback, the one that raised the exception
+            with suppress(Exception):
+                fi = inspect.getinnerframes(tb)[-1]
+                msg += f"\n  Callback error at: {fi.filename}:{fi.lineno}, in {fi.function}\n"  # noqa: E501
+                if fi.code_context:
+                    msg += f"    >  {fi.code_context[0].strip()}\n"
+                if flocals := fi.frame.f_locals:
+                    msg += "    Local variables:\n"
+                    for name, value in flocals.items():
+                        if name not in ("self", "cls"):
+                            msg += f"       {name} = {value!r}\n"
+
+        msg += f"\nSee {etype} above for original traceback."
         super().__init__(msg)

--- a/src/psygnal/_queue.py
+++ b/src/psygnal/_queue.py
@@ -94,4 +94,4 @@ def emit_queued(thread: Thread | None = None) -> None:
         try:
             cb(args)
         except Exception as e:  # pragma: no cover
-            raise EmitLoopError(cb=cb, args=args, exc=e) from e
+            raise EmitLoopError(exc=e) from e

--- a/tests/test_psygnal.py
+++ b/tests/test_psygnal.py
@@ -124,14 +124,20 @@ def test_decorator():
     err = ValueError()
 
     @emitter.one_int.connect
-    def boom(v: int):
+    def boom(v: int) -> None:
         raise err
 
     @emitter.one_int.connect(check_nargs=False)
     def bad_cb(a, b, c): ...
 
-    with pytest.raises(EmitLoopError) as e:
-        emitter.one_int.emit(1)
+    import re
+
+    error_re = re.compile(
+        "signal 'tests.test_psygnal.Emitter.one_int'" f".*{__file__}", re.DOTALL
+    )
+    with pytest.raises(EmitLoopError, match=error_re) as e:
+        emitter.one_int.emit(42)
+
     assert e.value.__cause__ is err
     assert e.value.__context__ is err
 

--- a/tests/test_psygnal.py
+++ b/tests/test_psygnal.py
@@ -134,7 +134,8 @@ def test_decorator():
     import re
 
     error_re = re.compile(
-        "signal 'tests.test_psygnal.Emitter.one_int'" f".*{__file__}", re.DOTALL
+        "signal 'tests.test_psygnal.Emitter.one_int'" f".*{re.escape(__file__)}",
+        re.DOTALL,
     )
     with pytest.raises(EmitLoopError, match=error_re) as e:
         emitter.one_int.emit(42)

--- a/tests/test_psygnal.py
+++ b/tests/test_psygnal.py
@@ -1124,9 +1124,7 @@ def test_emit_loop_error_message_construction(strategy: ReemissionVal) -> None:
     sig.connect(lambda v: v == 1 and sig.emit(2))  # type: ignore
     sig.connect(lambda v: v == 2 and sig.emit(0))  # type: ignore
     sig.connect(lambda v: 1 / v)
-    with pytest.raises(
-        EmitLoopError, match="While emitting signal <SignalInstance>"
-    ) as e:
+    with pytest.raises(EmitLoopError, match="While emitting signal") as e:
         sig.emit(1)
 
     if strategy == "queued":

--- a/tests/test_weak_callable.py
+++ b/tests/test_weak_callable.py
@@ -215,7 +215,9 @@ def test_cb_raises() -> None:
     t = T()
 
     sig.connect(t.method)
-    error_re = re.compile(f"emitting signal.*'sig'.*{__file__}.*method", re.DOTALL)
+    error_re = re.compile(
+        f"emitting signal.*'sig'.*{re.escape(__file__)}.*method", re.DOTALL
+    )
     with pytest.raises(EmitLoopError, match=error_re):
         sig.emit("a")
     sig.disconnect(t.method)

--- a/tests/test_weak_callable.py
+++ b/tests/test_weak_callable.py
@@ -223,12 +223,16 @@ def test_cb_raises() -> None:
     sig.disconnect(t.method)
 
     sig.connect_setattr(t, "x", maxargs=1)
-    error_re = re.compile(f"emitting signal.*'sig'.*{__file__}.*x", re.DOTALL)
+    error_re = re.compile(
+        f"emitting signal.*'sig'.*{re.escape(__file__)}.*x", re.DOTALL
+    )
     with pytest.raises(EmitLoopError, match=error_re):
         sig.emit("a")
     sig.disconnect_setattr(t, "x")
 
     sig.connect_setitem(t, "x", maxargs=1)
-    error_re = re.compile(f"emitting signal.*'sig'.*{__file__}.*__setitem__", re.DOTALL)
+    error_re = re.compile(
+        f"emitting signal.*'sig'.*{re.escape(__file__)}.*__setitem__", re.DOTALL
+    )
     with pytest.raises(EmitLoopError, match=error_re):
         sig.emit("a")

--- a/tests/test_weak_callable.py
+++ b/tests/test_weak_callable.py
@@ -28,7 +28,7 @@ from psygnal._weak_callback import WeakCallback, weak_callback
         "print",
     ],
 )
-def test_slot_types(type_: str, capsys) -> None:
+def test_slot_types(type_: str, capsys: Any) -> None:
     mock = Mock()
     final_mock = Mock()
 
@@ -86,6 +86,7 @@ def test_slot_types(type_: str, capsys) -> None:
         cb = weak_callback(print, finalize=final_mock)
 
     assert isinstance(cb, WeakCallback)
+    assert isinstance(cb.slot_repr(), str)
     cb.cb((2,))
     assert cb.dereference() is not None
     if type_ == "print":


### PR DESCRIPTION
This PR avoids the need to hang on to any information about the current callback & args by inspecting the stack after an exception happens.  I think it also makes the error a bit easier to read.

With the following error as an example:
```python
from psygnal import SignalInstance

sig = SignalInstance((int,), name="sig")

@sig.connect
def some_func(x: int) -> None:
    print(1 / x)

sig.emit(0)
```

before this PR:

```pytb
# ... stack trace
psygnal._exceptions.EmitLoopError:
While emitting signal 'builtins.NoneType.sig', an error occurred in callback '__main__.some_func'.
The args passed to the callback were: (0,)
This is not a bug in psygnal.  See 'ZeroDivisionError' above for details.
```

after this PR:
```pytb
# ... stack trace is the same
psygnal.EmitLoopError:

While emitting signal "<SignalInstance 'sig'>", an error occurred in a callback:
  File /Users/talley/dev/self/psygnal/x.py:8, in some_func
  With local variables:
    x = 0

See ZeroDivisionError above for details.
```

@Czaki, since it does some mildly deep inspection, your eyes on this would be appreciated.  