### PR TITLE
perf: let EventedSet use clear() method of underlying set

### DIFF
--- a/benchmarks/benchmarks.py
+++ b/benchmarks/benchmarks.py
@@ -258,7 +258,7 @@ class EventedSetSuite:
     def time_update_overlap(self, n):
         self.my_set.update(range(n // 2, n + n // 2))
 
-    def time_clear(self):
+    def time_clear(self, _):
         self.my_set.clear()
 
 

--- a/benchmarks/benchmarks.py
+++ b/benchmarks/benchmarks.py
@@ -258,6 +258,9 @@ class EventedSetSuite:
     def time_update_overlap(self, n):
         self.my_set.update(range(n // 2, n + n // 2))
 
+    def time_clear(self):
+        self.my_set.clear()
+
 
 class EventedSetWithCallbackSuite(EventedSetSuite):
     def setup(self, n):


### PR DESCRIPTION
Motivated by https://github.com/napari/napari/issues/6746, https://github.com/napari/napari/pull/6895

The default `clear` method implemented by `collections.abc.MutableSet` is very slow, which I guess is due to the fact that it is not backed by the C implementation of the builtin `set`. 

I have attempted to implement a custom interface for `clear`, modelled on the existing one for `discard`. However, I don't entirely understand the intentions for the various hooks, BAILs, etc, so please do let me know if anything is inconsistent with the behaviours and styles of other methods.

bench.py
```python
from psygnal.containers import EventedSet

num = 100_000

my_set = EventedSet(range(num))
my_set.events.items_changed.connect(print)
my_set.clear()
```
Before:
```cmd
> hyperfine --warmup 1 .\bench.py
Benchmark 1: .\bench.py
  Time (mean ± σ):      4.257 s ±  0.050 s    [User: 3.640 s, System: 0.047 s]
  Range (min … max):    4.192 s …  4.345 s    10 runs
```
After:
```cmd
> hyperfine --warmup 1 .\bench.py
Benchmark 1: .\bench.py
  Time (mean ± σ):     236.3 ms ±   3.4 ms    [User: 59.9 ms, System: 31.0 ms]
  Range (min … max):   231.6 ms … 243.9 ms    12 runs
```