### PR TITLE
feat: Add simple validator metadata for use in annotated

### DIFF
--- a/src/psygnal/__init__.py
+++ b/src/psygnal/__init__.py
@@ -34,6 +34,7 @@ __all__ = [
     "SignalGroupDescriptor",
     "SignalInstance",
     "throttled",
+    "Validator",
 ]
 
 
@@ -51,7 +52,12 @@ if os.getenv("PSYGNAL_UNCOMPILED"):
 from ._evented_decorator import evented
 from ._exceptions import EmitLoopError
 from ._group import EmissionInfo, SignalGroup
-from ._group_descriptor import SignalGroupDescriptor, get_evented_namespace, is_evented
+from ._group_descriptor import (
+    SignalGroupDescriptor,
+    Validator,
+    get_evented_namespace,
+    is_evented,
+)
 from ._queue import emit_queued
 from ._signal import Signal, SignalInstance, _compiled
 from ._throttler import debounced, throttled

--- a/src/psygnal/_evented_decorator.py
+++ b/src/psygnal/_evented_decorator.py
@@ -133,6 +133,7 @@ def evented(
         # as a decorator, this will have already been called
         descriptor.__set_name__(cls, events_namespace)
         setattr(cls, events_namespace, descriptor)
+        descriptor._do_patch_setattr(cls)
         return cls
 
     return _decorate(cls) if cls is not None else _decorate

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -1,0 +1,29 @@
+from dataclasses import dataclass
+from typing import Annotated, Any
+
+import pytest
+
+from psygnal import Validator, evented
+
+
+def test_validator():
+    def _is_positive(value: Any) -> int:
+        try:
+            _value = int(value)
+        except (ValueError, TypeError):
+            raise ValueError("Value must be an integer") from None
+        if not _value > 0:
+            raise ValueError("Value must be positive")
+        return _value
+
+    @evented
+    @dataclass
+    class Foo:
+        x: Annotated[int, Validator(_is_positive)]
+
+    with pytest.raises(ValueError, match="Value must be positive"):
+        Foo(x=-1)
+    foo = Foo(x="1")  # type: ignore
+    assert isinstance(foo.x, int)
+    with pytest.raises(ValueError):
+        foo.x = -1


### PR DESCRIPTION
Playing around with a pattern to add simple validation via `Annotated` on evented dataclasses.  There are *no* builtin validators.  It simply allows someone to declare some simple validation prior to event emission.  The use case would be when all you want is a way to cast fields without depending on a heavier library like pydantic. 

```python
    def positive_int(value: Any) -> int:
        try:
            _value = int(value)
        except (ValueError, TypeError):
            raise ValueError("Value must be an integer") from None
        if not _value > 0:
            raise ValueError("Value must be positive")
        return _value

    @evented
    @dataclass
    class Foo:
        x: Annotated[int, Validator(positive_int)]
```


(btw, @d-v-b, this is a general that might work for you in zarr.  The trick for you would just be determining when where to patch the `__setattr__` method of the parent class)

