### PR TITLE
CI: Update host OS version, add Python 3.13

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -56,12 +56,12 @@ jobs:
         include:
           - os: ubuntu-latest
             name: linux-x86_64
-          - os: windows-2019
+          - os: windows-latest
             name: windows-amd64
-          - os: macos-11
+          - os: macos-13
             name: macos-x86_64
             macos_arch: "x86_64"
-          - os: macos-11
+          - os: macos-14
             name: macos-arm64
             macos_arch: "arm64"
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,6 +46,8 @@ jobs:
           # still working on ci test errors
           - os: windows-latest
             python-version: "3.12"
+          - compile: true
+            python-version: "3.13"
 
   test-qt:
     name: Test Qt
@@ -71,7 +73,7 @@ jobs:
         include:
           - os: macos-13
             qt: PySide2
-  
+
   upload_coverage:
     if: always()
     needs: [test, test-qt]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,7 +32,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
         os: [ubuntu-latest, macos-latest, windows-latest]
         compile: [true, false]
         include:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,7 @@ test = [
     "pytest>=6.0",
     "pytest-cov",
     "wrapt",
-    "msgspec",
+    "msgspec; python_version < '3.13'",
     "toolz",
 ]
 testqt = ["pytest-qt", "qtpy"]


### PR DESCRIPTION
Some CI maintenance:
- Update the Pypi.yml host OSes to their latest compatible versions
- Add Python 3.13 to the test matrix.
  - This needs https://github.com/pyapp-kit/workflows/pull/10