### PR TITLE
fast: add `emit_fast` method for 10x faster emission (without safety checks)

### DIFF
--- a/benchmarks/benchmarks.py
+++ b/benchmarks/benchmarks.py
@@ -138,6 +138,11 @@ class EmitSuite:
     def time_emit_to_partial(self, n: int) -> None:
         self.emitter6.changed.emit(1)
 
+    if hasattr(SignalInstance, "emit_fast"):
+
+        def time_emit_fast_to_function(self, n: int) -> None:
+            self.emitter1.changed.emit_fast(1)
+
 
 class EventedModelSuite:
     params = [10, 100]

--- a/benchmarks/benchmarks.py
+++ b/benchmarks/benchmarks.py
@@ -138,9 +138,6 @@ class EmitSuite:
     def time_emit_to_partial(self, n: int) -> None:
         self.emitter6.changed.emit(1)
 
-    def time_emit_fast(self, n: int) -> None:
-        self.emitter1.changed.emit_fast(1)
-
 
 class EventedModelSuite:
     params = [10, 100]

--- a/benchmarks/benchmarks.py
+++ b/benchmarks/benchmarks.py
@@ -138,10 +138,8 @@ class EmitSuite:
     def time_emit_to_partial(self, n: int) -> None:
         self.emitter6.changed.emit(1)
 
-    if hasattr(SignalInstance, "emit_fast"):
-
-        def time_emit_fast_to_function(self, n: int) -> None:
-            self.emitter1.changed.emit_fast(1)
+    def time_emit_fast(self, n: int) -> None:
+        self.emitter1.changed.emit_fast(1)
 
 
 class EventedModelSuite:

--- a/src/psygnal/_signal.py
+++ b/src/psygnal/_signal.py
@@ -1175,6 +1175,52 @@ class SignalInstance:
 
         self._run_emit_loop(args)
 
+    def emit_fast(self, *args: Any) -> None:
+        """Fast emit without any checks.
+
+        This method can be up to 10x faster than `emit()`, but it lacks most of the
+        features and safety checks of `emit()`. Use with caution.  Specifically:
+
+        - It does not support `check_nargs` or `check_types`
+        - It does not use any thread safety locks.
+        - It is not possible to query the emitter with `Signal.current_emitter()`
+        - It is not possible to query the sender with `Signal.sender()`
+        - It does not support "queued" or "latest-only" reemission modes for nested
+          emits. It will always use "immediate" mode, wherein signals emitted by
+          callbacks are immediately processed in a deeper emission loop.
+
+        It DOES, however, support `paused()` and `blocked()`
+
+        Parameters
+        ----------
+        *args : Any
+            These arguments will be passed when calling each slot (unless the slot
+            accepts fewer arguments, in which case extra args will be discarded.)
+        """
+        if self._is_blocked:
+            return
+
+        if self._is_paused:
+            self._args_queue.append(args)
+            return
+
+        try:
+            for caller in self._slots:
+                caller.cb(args)
+        except RecursionError as e:
+            raise RecursionError(
+                f"RecursionError when "
+                f"emitting signal {self.name!r} with args {args}"
+            ) from e
+        except Exception as cb_err:
+            if isinstance(cb_err, EmitLoopError):
+                raise cb_err
+            loop_err = EmitLoopError(exc=cb_err, signal=self).with_traceback(
+                cb_err.__traceback__
+            )
+            # this comment will show up in the traceback
+            raise loop_err from cb_err  # emit() call ABOVE || callback error BELOW
+
     def __call__(
         self, *args: Any, check_nargs: bool = False, check_types: bool = False
     ) -> None:

--- a/src/psygnal/_signal.py
+++ b/src/psygnal/_signal.py
@@ -1212,9 +1212,9 @@ class SignalInstance:
                 f"RecursionError when "
                 f"emitting signal {self.name!r} with args {args}"
             ) from e
+        except EmitLoopError as e:  # pragma: no cover
+            raise e
         except Exception as cb_err:
-            if isinstance(cb_err, EmitLoopError):
-                raise cb_err
             loop_err = EmitLoopError(exc=cb_err, signal=self).with_traceback(
                 cb_err.__traceback__
             )
@@ -1245,9 +1245,9 @@ class SignalInstance:
                     f"RecursionError when "
                     f"emitting signal {self.name!r} with args {args}"
                 ) from e
+            except EmitLoopError as e:
+                raise e
             except Exception as cb_err:
-                if isinstance(cb_err, EmitLoopError):
-                    raise cb_err
                 loop_err = EmitLoopError(
                     exc=cb_err,
                     signal=self,

--- a/tests/test_bench.py
+++ b/tests/test_bench.py
@@ -121,6 +121,12 @@ def test_emit_time(benchmark: Callable, n_connections: int, callback_type: str) 
     benchmark(emitter.one_int.emit, 1)
 
 
+def test_emit_fast(benchmark: Callable) -> None:
+    emitter = Emitter()
+    emitter.one_int.connect(one_int)
+    benchmark(emitter.one_int.emit_fast, 1)
+
+
 @pytest.mark.benchmark
 def test_evented_creation() -> None:
     @evented

--- a/tests/test_psygnal.py
+++ b/tests/test_psygnal.py
@@ -120,6 +120,20 @@ def test_basic_signal():
     mock.assert_called_once_with(1)
 
 
+def test_emit_fast():
+    """Test emit_fast method."""
+    emitter = Emitter()
+    mock = MagicMock()
+    emitter.one_int.connect(mock)
+    emitter.one_int.emit_fast(1)
+    mock.assert_called_once_with(1)
+    mock.reset_mock()
+
+    # calling directly also works
+    emitter.one_int(1)
+    mock.assert_called_once_with(1)
+
+
 def test_decorator():
     emitter = Emitter()
     err = ValueError()


### PR DESCRIPTION
This PR is in response to @beniroquai's https://github.com/pyapp-kit/psygnal/issues/330#issuecomment-2436321438:

> but the frame-rate drops significantly in the psygnal case

Indeed, the compiled version of psygnal is roughly 5 times slower than Qt (the uncompiled version is about 6.5-7 times slower).  It looks like all that slowdown comes from safety mechanisms and other "features" that may not be used in many cases, (like the ability to query the sender, etc...).  So, this PR adds a stripped down `emit_fast()` method that has the following changes:

  - It does not support `check_nargs` or `check_types`
  - It does not use any thread safety locks.
  - It is not possible to query the emitter with `Signal.current_emitter()`
  - It is not possible to query the sender with `Signal.sender()`
  - It does not support "queued" or "latest-only" reemission modes for nested
    emits. It will always use "immediate" mode, wherein signals emitted by
    callbacks are immediately processed in a deeper emission loop.

  It DOES, however, respect `paused()` and `blocked()`

By stripping away those less-used features, the emission is about 10x faster (making the compiled version ~2x faster than Qt).  It should be used with caution, but for most simple cases, it is probably everything one needs.
