### PR TITLE
refactor: update exception message

### DIFF
--- a/asv.conf.json
+++ b/asv.conf.json
@@ -10,7 +10,7 @@
   "show_commit_url": "https://github.com/pyapp-kit/psygnal/commit/",
   "pythons": ["3.11"],
   "build_command": [
-    "python -m pip install build 'hatchling==1.21.1' hatch-vcs hatch-mypyc mypy pydantic!=2.10.0 types-attrs msgspec",
+    "python -m pip install build 'hatchling==1.21.1' hatch-vcs hatch-mypyc mypy==1.13.0 pydantic!=2.10.0 types-attrs msgspec",
     "python -c \"import os; from pathlib import Path; import hatchling.builders.wheel as h; p = Path(h.__file__); targ = os.environ.get('MACOSX_DEPLOYMENT_TARGET', '10_16').replace('.', '_'); txt = p.read_text().replace('10_16', targ); p.write_text(txt)\"",
     "python -m build --wheel -o {build_cache_dir} {build_dir} --no-isolation"
   ],

--- a/src/psygnal/_exceptions.py
+++ b/src/psygnal/_exceptions.py
@@ -4,7 +4,7 @@ import inspect
 import os
 from contextlib import suppress
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 import psygnal
 
@@ -38,16 +38,15 @@ class EmitLoopError(Exception):
 
         # grab the signal name or repr
         if signal is None:  # pragma: no cover
-            sig_name: Any = ""
+            sig_name: str = ""
+        elif instance := signal.instance:
+            inst_class = instance.__class__
+            mod = getattr(inst_class, "__module__", "")
+            if mod:
+                mod += "."
+            sig_name = f"{mod}{inst_class.__qualname__}.{signal.name}"
         else:
-            if instsance := signal.instance:
-                inst_class = instsance.__class__
-                mod = getattr(inst_class, "__module__", "")
-                if mod:
-                    mod += "."
-                sig_name = f"{mod}{inst_class.__qualname__}.{signal.name}"
-            else:
-                sig_name = signal
+            sig_name = signal.name
 
         msg = _build_psygnal_exception_msg(sig_name, exc, recursion_depth)
 
@@ -87,7 +86,7 @@ def _build_psygnal_exception_msg(
     if tb := exc.__traceback__:
         with suppress(Exception):
             if not (inner := inspect.getinnerframes(tb)):
-                return msg
+                return msg  # pragma: no cover
 
             except_frame = inner[-1]
 

--- a/src/psygnal/_exceptions.py
+++ b/src/psygnal/_exceptions.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import inspect
+import os
 from contextlib import suppress
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -8,7 +9,7 @@ from typing import TYPE_CHECKING, Any
 import psygnal
 
 if TYPE_CHECKING:
-    from collections.abc import Sequence
+    from collections.abc import Container, Sequence
 
     from ._signal import SignalInstance
 
@@ -48,37 +49,7 @@ class EmitLoopError(Exception):
             else:
                 sig_name = signal
 
-        etype = exc.__class__.__name__  # name of the exception raised by callback.
-        msg = (
-            f"\n\nWhile emitting signal {sig_name!r}, a {etype} occurred in a callback"
-        )
-        if recursion_depth:
-            s = "s" if recursion_depth > 1 else ""
-            msg += f"\nnested {recursion_depth} level{s} deep"
-        if tb := exc.__traceback__:
-            msg += ":\n"
-
-            # get the first frame in the stack that is not in the psygnal package
-            with suppress(Exception):
-                fi = next(fi for fi in inspect.stack() if ROOT not in fi.filename)
-                msg += f"\n  Signal emitted at: {fi.filename}:{fi.lineno}, in {fi.function}\n"  # noqa: E501
-                if fi.code_context:
-                    msg += f"    >  {fi.code_context[0].strip()}\n"
-
-            # get the last frame in the traceback, the one that raised the exception
-            with suppress(Exception):
-                fi = inspect.getinnerframes(tb)[-1]
-                msg += f"\n  Callback error at: {fi.filename}:{fi.lineno}, in {fi.function}\n"  # noqa: E501
-                if fi.code_context:
-                    msg += f"    >  {fi.code_context[0].strip()}\n"
-                if flocals := fi.frame.f_locals:
-                    msg += "\n    Local variables:\n"
-                    for name, value in flocals.items():
-                        if name not in ("self", "cls"):
-                            val_repr = repr(value)
-                            if len(val_repr) > 60:
-                                val_repr = val_repr[:60] + "..."  # pragma: no cover
-                            msg += f"       {name} = {val_repr}\n"
+        msg = _build_psygnal_exception_msg(sig_name, exc, recursion_depth)
 
         # queued emission can be confusing, because the `signal.emit()` call shown
         # in the traceback will not match the emission that actually raised the error.
@@ -87,6 +58,72 @@ class EmitLoopError(Exception):
                 "\nNOTE: reemission is set to 'queued', and this error occurred "
                 f"at a queue-depth of {depth}.\nEmitting arguments: {emit_queue[-1]})\n"
             )
-        msg += f"\nSee {etype} above for original traceback."
 
         super().__init__(msg)
+
+
+def _build_psygnal_exception_msg(
+    sig_name: str, exc: BaseException, recursion_depth: int
+) -> str:
+    msg = f"\n\nWhile emitting signal {sig_name!r}, an error occurred in a callback:"
+    line = f"\n\n  {exc.__class__.__name__}: {exc}"
+    msg += line + "\n  " + "-" * (len(line) - 4)
+
+    if recursion_depth:
+        s = "s" if recursion_depth > 1 else ""
+        msg += f"\nnested {recursion_depth} level{s} deep"
+
+    # get the first frame in the stack that is not in the psygnal package
+    stack = inspect.stack()
+    with suppress(Exception):
+        emit_frame = next(fi for fi in stack if ROOT not in fi.filename)
+        msg += "\n\n  SIGNAL EMISSION: \n"
+        with suppress(IndexError):
+            back_frame = stack[stack.index(emit_frame) + 1]
+            msg += f"    {_fmt_frame(back_frame)}\n"
+        msg += f"    {_fmt_frame(emit_frame)}  # <-- SIGNAL WAS EMITTED HERE\n"
+
+    # get the last frame in the traceback, the one that raised the exception
+    if tb := exc.__traceback__:
+        with suppress(Exception):
+            if not (inner := inspect.getinnerframes(tb)):
+                return msg
+
+            except_frame = inner[-1]
+
+            # show the immediately connected callback first
+            first_cb = next((fi for fi in inner if ROOT not in fi.filename), None)
+            if first_cb and first_cb != except_frame:
+                num_inner = len(inner) - inner.index(first_cb) - 2
+                msg += "\n  CALLBACK CHAIN:\n"
+                msg += f"    {_fmt_frame(first_cb, with_context=False)}"
+                msg += f"    ... {num_inner} more frames ...\n"
+
+            # Then end with the frame that raised the exception
+            msg += f"    {_fmt_frame(except_frame)}  # <-- ERROR OCCURRED HERE \n"
+            if flocals := except_frame.frame.f_locals:
+                if not os.getenv("PSYGNAL_HIDE_LOCALS"):
+                    msg += "\n      Local variables:\n"
+                    msg += _fmt_locals(flocals)
+
+    return msg
+
+
+def _fmt_frame(fi: inspect.FrameInfo, with_context: bool = True) -> str:
+    msg = f"{fi.filename}:{fi.lineno} in {fi.function}\n"
+    if with_context and (code_ctx := fi.code_context):
+        msg += f"      {code_ctx[0].strip()}"
+    return msg
+
+
+def _fmt_locals(
+    f_locals: dict, exclude: Container[str] = ("self", "cls"), name_width: int = 20
+) -> str:
+    lines = []
+    for name, value in f_locals.items():
+        if name not in exclude:
+            val_repr = repr(value)
+            if len(val_repr) > 60:
+                val_repr = val_repr[:60] + "..."  # pragma: no cover
+            lines.append("{:>{}} = {}".format(name, name_width, val_repr))
+    return "\n".join(lines)


### PR DESCRIPTION
yet another update to how the emit loop error exception looks.  with this PR it will now look something like this:

```pytb
While emitting signal 'ndv.models._mapping.ValidatedEventedDict.value_changed', an error occurred in a callback:

  ValueError: Dimensions {0, 1, 2} do not exist. Expected one or more of ('time', 'lat', 'lon')
  ---------------------------------------------------------------------------------------------

  SIGNAL EMISSION: 
    /Users/talley/dev/self/ndv/src/ndv/controllers/_array_viewer.py:302 in _on_view_current_index_changed
      self._data_model.display.current_index.update(self._view.current_index())
    /Users/talley/dev/self/ndv/src/ndv/models/_mapping.py:187 in update
      self.value_changed.emit()  # <-- SIGNAL WAS EMITTED HERE

  CALLBACK CHAIN:
    /Users/talley/dev/self/ndv/src/ndv/controllers/_array_viewer.py:275 in _on_model_current_index_changed
    ... 6 more frames ...
    /Users/talley/dev/self/ndv/.venv/lib/python3.12/site-packages/xarray/core/utils.py:802 in drop_dims_from_indexers
      raise ValueError(  # <-- ERROR OCCURRED HERE 

      Local variables:
            indexers = {1: slice(None, None, None), 2: slice(None, None, None), 0: ...
                dims = ('time', 'lat', 'lon')
        missing_dims = 'raise'
             invalid = {0, 1, 2}
```