### PR TITLE
fix: use safer repr in warning

### DIFF
--- a/src/psygnal/_weak_callback.py
+++ b/src/psygnal/_weak_callback.py
@@ -259,7 +259,7 @@ class WeakCallback(Generic[_R]):
             if self._on_ref_error == "raise":
                 raise
             if self._on_ref_error == "warn":
-                safe_repr = f"<{type(obj).__name__} at {hex(id(obj))}>"
+                safe_repr = object.__repr__(obj)
                 warn(
                     f"failed to create weakref for {safe_repr}, returning strong ref",
                     stacklevel=2,

--- a/src/psygnal/_weak_callback.py
+++ b/src/psygnal/_weak_callback.py
@@ -259,8 +259,9 @@ class WeakCallback(Generic[_R]):
             if self._on_ref_error == "raise":
                 raise
             if self._on_ref_error == "warn":
+                safe_repr = f"<{type(obj).__name__} at {hex(id(obj))}>"
                 warn(
-                    f"failed to create weakref for {obj!r}, returning strong ref",
+                    f"failed to create weakref for {safe_repr}, returning strong ref",
                     stacklevel=2,
                 )
 


### PR DESCRIPTION
I found an edge case when trying to connect to a slot, where that slot itself had a recursion error in its `__repr__` method, where the entire connection failed with a recursion error in what should have been a simple warning when the slot was not weak-refable.  This PR uses `object.__repr__(object)` instead of `repr(object)`, just in case the object in question in un-reprable