### PR TITLE
refactor: have EmitLoopError inherit RuntimeError

### DIFF
--- a/src/psygnal/_exceptions.py
+++ b/src/psygnal/_exceptions.py
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
 ROOT = str(Path(psygnal.__file__).parent)
 
 
-class EmitLoopError(Exception):
+class EmitLoopError(RuntimeError):
     """Error type raised when an exception occurs during a callback."""
 
     __module__ = "psygnal"


### PR DESCRIPTION
@Czaki how do you feel about this change.

I think it more accurately captures the semantics of an error during a callback, and it also is useful for try/except when you're also dealing with C++ object deleted from the qt side