### PR TITLE
Don't use deprecated model_fields access

### DIFF
--- a/src/psygnal/_evented_model.py
+++ b/src/psygnal/_evented_model.py
@@ -111,7 +111,8 @@ if not PYDANTIC_V1:
     ) -> dict[str, Any]:
         """Get possibly nested default values for a Model object."""
         dflt = {}
-        for k, v in type(obj).model_fields.items():
+        cls = obj if isinstance(obj, type) else type(obj)
+        for k, v in cls.model_fields.items():
             d = v.get_default()
             if (
                 d is None
@@ -125,7 +126,9 @@ if not PYDANTIC_V1:
     def _get_config(cls: pydantic.BaseModel) -> "ConfigDict":
         return cls.model_config
 
-    def _get_fields(cls: pydantic.BaseModel) -> dict[str, pydantic.fields.FieldInfo]:
+    def _get_fields(
+        cls: type[pydantic.BaseModel],
+    ) -> dict[str, pydantic.fields.FieldInfo]:
         return cls.model_fields
 
     def _model_dump(obj: pydantic.BaseModel) -> dict:

--- a/src/psygnal/_evented_model.py
+++ b/src/psygnal/_evented_model.py
@@ -111,7 +111,7 @@ if not PYDANTIC_V1:
     ) -> dict[str, Any]:
         """Get possibly nested default values for a Model object."""
         dflt = {}
-        for k, v in obj.model_fields.items():
+        for k, v in type(obj).model_fields.items():
             d = v.get_default()
             if (
                 d is None
@@ -547,7 +547,7 @@ class EventedModel(pydantic.BaseModel, metaclass=EventedMetaclass):
     def reset(self) -> None:
         """Reset the state of the model to default values."""
         model_config = _get_config(self)
-        model_fields = _get_fields(self)
+        model_fields = _get_fields(type(self))
         for name, value in self._defaults.items():
             if isinstance(value, EventedModel):
                 cast("EventedModel", getattr(self, name)).reset()


### PR DESCRIPTION
Pydantic 2.11 has deprecated accessing model_fields from instances of the model class, instead requiring callers to use the class itself.

Fixes #356