### PR TITLE
feat: add testing utilities

### DIFF
--- a/docs/guides/testing.md
+++ b/docs/guides/testing.md
@@ -1,0 +1,71 @@
+# Testing with `psygnal`
+
+If you would like to test to ensure that signals are emitted (or not emitted) as
+expected, you can use the convenience functions in the
+[`psygnal.testing`][psygnal.testing] module.
+
+## Examples
+
+The easiest approach is to use one of the `assert_*` context
+managers.  These temporarily listen to a signal and check if it is
+emitted (or not emitted) when the context is exited.  The API
+closely mirrors the [`unittest.mock`][unittest.mock.Mock.assert_called] API,
+with the word "called" replaced with "emitted".
+
+```python
+from psygnal import Signal
+import psygnal.testing as pt
+
+class MyObject:
+    changed = Signal()
+    value_changed = Signal(int)
+
+def test_my_object():
+    obj = MyObject()
+
+    with pt.assert_emitted(obj.changed):
+        obj.changed.emit()
+    
+    with pt.assert_not_emitted(obj.value_changed):
+        obj.changed.emit()
+    
+    with pt.assert_emitted_once(obj.value_changed):
+        obj.value_changed.emit(42)
+
+    with pt.assert_emitted_once_with(obj.value_changed, 42):
+        obj.value_changed.emit(42)
+
+    with pt.assert_ever_emitted_with(obj.value_changed, 42):
+        obj.value_changed.emit(41)
+        obj.value_changed.emit(42)
+        obj.value_changed.emit(43)
+```
+
+All of the context managers yield an instance of
+[`SignalTester`][psygnal.testing.SignalTester], which can be used to check the
+number of emissions and the arguments. It may also be used directly:
+
+```python
+from psygnal import Signal
+import psygnal.testing as pt
+
+class MyObject:
+    value_changed = Signal(int)
+
+def test_my_object():
+    obj = MyObject()
+    tester = pt.SignalTester(obj.value_changed)
+
+    with tester:
+        obj.value_changed.emit(42)
+        obj.value_changed.emit(43)
+
+    assert tester.emit_count == 2
+    assert tester.emit_args_list == [(42,), (43,)]
+    assert tester.emit_args == (43,)
+    tester.assert_ever_emitted_with(42)
+    tester.assert_emitted_with(43)
+```
+
+See API documentation for
+[`SignalTester`][psygnal.testing.SignalTester] for more details.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -24,6 +24,7 @@ nav:
     - Evented Dataclasses: guides/dataclasses.md
     - Evented Pydantic Model: guides/model.md
     - Throttling & Debouncing: guides/throttler.md
+    - Testing: guides/testing.md
     - Debugging: guides/debugging.md
 
 theme:

--- a/src/psygnal/testing.py
+++ b/src/psygnal/testing.py
@@ -1,0 +1,96 @@
+"""Utilities for testing psygnal Signals."""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from typing import TYPE_CHECKING
+from unittest.mock import Mock
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+    from typing import Any, Self
+
+    import psygnal
+
+
+class SignalMock(Mock):
+    """A mock for a psygnal Signal."""
+
+    def __init__(self, signal_instance: psygnal.SignalInstance) -> None:
+        super().__init__()
+        self.signal_instance = signal_instance
+
+    def connect(self) -> None:
+        """Connect the mock to the signal."""
+        self.signal_instance.connect(self)
+
+    def disconnect(self) -> None:
+        """Disconnect the mock from the signal."""
+        self.signal_instance.disconnect(self)
+
+    def __enter__(self) -> Self:
+        """Connect the mock to the signal."""
+        self.connect()
+        return self
+
+    def __exit__(self, *args: Any) -> None:
+        """Disconnect the mock from the signal."""
+        self.signal_instance.disconnect(self)
+
+    @property
+    def signal_name(self) -> str:
+        """Return the name of the signal."""
+        return self.signal_instance.name or "signal"
+
+    def assert_not_emitted(self):
+        """Assert that the signal was never emitted."""
+        if self.call_count != 0:
+            raise AssertionError(
+                f"Expected {self.signal_name!r} to not have been emitted."
+                f"Called {self.call_count} times."
+            )
+
+    def assert_emitted(self) -> None:
+        """Assert that the signal was emitted at least once."""
+        if self.call_count == 0:
+            raise AssertionError(f"Expected {self.signal_name!r} to have been emitted.")
+
+    def assert_emitted_once(self):
+        """Assert that the signal was emitted exactly once."""
+        if not self.call_count == 1:
+            raise AssertionError(
+                f"Expected {self.signal_name!r} to have been emitted once."
+                f"Called {self.call_count} times."
+            )
+
+    def assert_emitted_with(self, /, *args: Any) -> None:
+        """Assert that the last call to the signal was with the given arguments."""
+        super().assert_called_with(*args)
+
+
+@contextmanager
+def assert_emitted(signal: psygnal.SignalInstance) -> Iterator[Mock]:
+    """Assert that a signal was emitted at least once."""
+    with SignalMock(signal) as mock:
+        yield mock
+        mock.assert_emitted()
+
+
+@contextmanager
+def assert_emitted_once(signal: psygnal.SignalInstance) -> Iterator[Mock]:
+    """Assert that a signal was emitted exactly once."""
+    with SignalMock(signal) as mock:
+        yield mock
+        mock.assert_emitted_once()
+
+
+@contextmanager
+def assert_emitted_with(signal: psygnal.SignalInstance, *args: Any) -> Iterator[Mock]:
+    """Assert that a signal was emitted with the given arguments."""
+    with assert_emitted(signal) as mock:
+        yield mock
+    mock.call_args[0][0]
+    # if isinstance(val, np.ndarray):
+    #     np.testing.assert_array_almost_equal(val, value, decimal=6)
+    # else:
+    #     assert val == value

--- a/src/psygnal/testing.py
+++ b/src/psygnal/testing.py
@@ -9,7 +9,9 @@ from unittest.util import safe_repr
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
-    from typing import Any, Self
+    from typing import Any
+
+    from typing_extensions import Self
 
     import psygnal
 

--- a/src/psygnal/testing.py
+++ b/src/psygnal/testing.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from contextlib import contextmanager
 from typing import TYPE_CHECKING
 from unittest.mock import Mock
+from unittest.util import safe_repr
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
@@ -12,21 +13,105 @@ if TYPE_CHECKING:
 
     import psygnal
 
+__all__ = [
+    "SignalTester",
+    "assert_emitted",
+    "assert_emitted_once",
+    "assert_emitted_once_with",
+    "assert_emitted_with",
+    "assert_ever_emitted_with",
+    "assert_not_emitted",
+]
 
-class SignalMock(Mock):
-    """A mock for a psygnal Signal."""
+
+class SignalTester:
+    """A tester object that listens to a signal and records its emissions.
+
+    This class wraps a [`psygnal.SignalInstance`][] and a [`unittest.mock.Mock`][]
+    object. It provides methods to connect and disconnect the mock from the signal, and
+    to assert that the signal was emitted with the expected arguments.  It also behaves
+    as a **context manager**, so you can monitor emissions of a signal within a specific
+    context.
+
+    !!! important
+
+        The signal is *not* automatically connected to the mock when the SignalTester is
+        created. You must call [`connect()`][psygnal.testing.SignalTester.connect] or
+        use the context manager to connect the mock to the signal.
+
+    Parameters
+    ----------
+    signal_instance : psygnal.SignalInstance
+        The signal instance to test.
+
+    Attributes
+    ----------
+    signal_instance : psygnal.SignalInstance
+        The signal instance to test.
+    mock : unittest.mock.Mock
+        The mock object that will be connected to the signal.
+
+    Examples
+    --------
+    ```python
+    from psygnal import Signal
+    from psygnal.testing import SignalTester
+
+
+    class MyObject:
+        value_changed = Signal(int)
+
+
+    obj = MyObject()
+    tester = SignalTester(obj.value_changed)
+    tester.assert_not_emitted()
+
+    with tester:
+        obj.value_changed.emit(1)
+
+    tester.assert_emitted()
+    tester.assert_emitted_once()
+    tester.assert_emitted_once_with(1)
+    assert tester.emit_count == 1
+    tester.reset()
+    assert tester.emit_count == 0
+    ```
+    """
 
     def __init__(self, signal_instance: psygnal.SignalInstance) -> None:
         super().__init__()
+        self.mock = Mock()
         self.signal_instance = signal_instance
+
+    def reset(self) -> None:
+        """Reset the underlying mock object."""
+        self.mock.reset_mock()
+
+    @property
+    def emit_count(self) -> int:
+        """Return the number of times the signal was emitted."""
+        return self.mock.call_count
+
+    @property
+    def emit_args(self) -> tuple[Any, ...]:
+        """Return the arguments of the last emission of the signal."""
+        if (call_args := self.mock.call_args) is None:
+            return ()
+
+        return call_args[0]  # type: ignore[no-any-return]
+
+    @property
+    def emit_args_list(self) -> list[tuple[Any, ...]]:
+        """Return the arguments of all emissions of the signal."""
+        return [call[0] for call in self.mock.call_args_list]
 
     def connect(self) -> None:
         """Connect the mock to the signal."""
-        self.signal_instance.connect(self)
+        self.signal_instance.connect(self.mock)
 
     def disconnect(self) -> None:
         """Disconnect the mock from the signal."""
-        self.signal_instance.disconnect(self)
+        self.signal_instance.disconnect(self.mock)
 
     def __enter__(self) -> Self:
         """Connect the mock to the signal."""
@@ -35,62 +120,208 @@ class SignalMock(Mock):
 
     def __exit__(self, *args: Any) -> None:
         """Disconnect the mock from the signal."""
-        self.signal_instance.disconnect(self)
+        self.disconnect()
 
     @property
     def signal_name(self) -> str:
         """Return the name of the signal."""
         return self.signal_instance.name or "signal"
 
-    def assert_not_emitted(self):
+    def assert_not_emitted(self) -> None:
         """Assert that the signal was never emitted."""
-        if self.call_count != 0:
+        if self.mock.call_count != 0:
+            if self.mock.call_count == 1:
+                n = "once"
+            else:
+                n = f"{self.mock.call_count} times"
             raise AssertionError(
-                f"Expected {self.signal_name!r} to not have been emitted."
-                f"Called {self.call_count} times."
+                f"Expected {self.signal_name!r} to not have been emitted. Emitted {n}."
             )
 
     def assert_emitted(self) -> None:
         """Assert that the signal was emitted at least once."""
-        if self.call_count == 0:
+        if self.mock.call_count == 0:
             raise AssertionError(f"Expected {self.signal_name!r} to have been emitted.")
 
-    def assert_emitted_once(self):
+    def assert_emitted_once(self) -> None:
         """Assert that the signal was emitted exactly once."""
-        if not self.call_count == 1:
+        if not self.mock.call_count == 1:
             raise AssertionError(
-                f"Expected {self.signal_name!r} to have been emitted once."
-                f"Called {self.call_count} times."
+                f"Expected {self.signal_name!r} to have been emitted once. "
+                f"Emitted {self.mock.call_count} times."
             )
 
     def assert_emitted_with(self, /, *args: Any) -> None:
-        """Assert that the last call to the signal was with the given arguments."""
-        super().assert_called_with(*args)
+        """Assert that the *last* emission of the signal had the given arguments."""
+        if self.mock.call_args is None:
+            raise AssertionError(
+                f"Expected {self.signal_name!r} to have been emitted with arguments "
+                f"{args!r}.\nActual: not emitted"
+            )
+
+        actual = self.mock.call_args[0]
+        if actual != args:
+            raise AssertionError(
+                f"Expected {self.signal_name!r} to have been emitted with arguments "
+                f"{args!r}.\nActual: {actual}"
+            )
+
+    def assert_emitted_once_with(self, /, *args: Any) -> None:
+        """Assert that the signal was emitted exactly once with the given arguments."""
+        if not self.mock.call_count == 1:
+            raise AssertionError(
+                f"Expected {self.signal_name!r} to have been emitted exactly once. "
+                f"Emitted {self.mock.call_count} times."
+            )
+
+        actual = self.mock.call_args[0]
+        if actual != args:
+            raise AssertionError(
+                f"Expected {self.signal_name!r} to have been emitted once with "
+                f"arguments {args!r}.\nActual: {safe_repr(actual)}"
+            )
+
+    def assert_ever_emitted_with(self, /, *args: Any) -> None:
+        """Assert that the signal was emitted *ever* with the given arguments."""
+        if self.mock.call_args is None:
+            raise AssertionError(
+                f"Expected {self.signal_name!r} to have been emitted at least once "
+                f"with arguments {args!r}.\nActual: not emitted"
+            )
+
+        actual = [call[0] for call in self.mock.call_args_list]
+        if not any(call == args for call in actual):
+            _actual: tuple | list = actual[0] if len(actual) == 1 else actual
+            raise AssertionError(
+                f"Expected {self.signal_name!r} to have been emitted at least once "
+                f"with arguments {args!r}.\nActual: {safe_repr(_actual)}"
+            )
 
 
 @contextmanager
-def assert_emitted(signal: psygnal.SignalInstance) -> Iterator[Mock]:
-    """Assert that a signal was emitted at least once."""
-    with SignalMock(signal) as mock:
+def assert_emitted(signal: psygnal.SignalInstance) -> Iterator[SignalTester]:
+    """Assert that a signal was emitted at least once.
+
+    Parameters
+    ----------
+    signal : psygnal.SignalInstance
+        The signal instance to test.
+
+    Raises
+    ------
+    AssertionError
+        If the signal was never emitted.
+    """
+    with SignalTester(signal) as mock:
         yield mock
         mock.assert_emitted()
 
 
 @contextmanager
-def assert_emitted_once(signal: psygnal.SignalInstance) -> Iterator[Mock]:
-    """Assert that a signal was emitted exactly once."""
-    with SignalMock(signal) as mock:
+def assert_emitted_once(signal: psygnal.SignalInstance) -> Iterator[SignalTester]:
+    """Assert that a signal was emitted exactly once.
+
+    Parameters
+    ----------
+    signal : psygnal.SignalInstance
+        The signal instance to test.
+
+    Raises
+    ------
+    AssertionError
+        If the signal was emitted more than once.
+    """
+    with SignalTester(signal) as mock:
         yield mock
         mock.assert_emitted_once()
 
 
 @contextmanager
-def assert_emitted_with(signal: psygnal.SignalInstance, *args: Any) -> Iterator[Mock]:
-    """Assert that a signal was emitted with the given arguments."""
+def assert_not_emitted(signal: psygnal.SignalInstance) -> Iterator[SignalTester]:
+    """Assert that a signal was never emitted.
+
+    Parameters
+    ----------
+    signal : psygnal.SignalInstance
+        The signal instance to test.
+
+    Raises
+    ------
+    AssertionError
+        If the signal was emitted at least once.
+    """
+    with SignalTester(signal) as mock:
+        yield mock
+        mock.assert_not_emitted()
+
+
+@contextmanager
+def assert_emitted_with(
+    signal: psygnal.SignalInstance, *args: Any
+) -> Iterator[SignalTester]:
+    """Assert that the *last* emission of the signal had the given arguments.
+
+    Parameters
+    ----------
+    signal : psygnal.SignalInstance
+        The signal instance to test.
+    args : Any
+        The arguments to check for in the last emission of the signal.
+
+    Raises
+    ------
+    AssertionError
+        If the signal was never emitted or if the last emission did not have the
+        expected arguments.
+    """
     with assert_emitted(signal) as mock:
         yield mock
-    mock.call_args[0][0]
-    # if isinstance(val, np.ndarray):
-    #     np.testing.assert_array_almost_equal(val, value, decimal=6)
-    # else:
-    #     assert val == value
+        mock.assert_emitted_with(*args)
+
+
+@contextmanager
+def assert_emitted_once_with(
+    signal: psygnal.SignalInstance, *args: Any
+) -> Iterator[SignalTester]:
+    """Assert that the signal was emitted exactly once with the given arguments.
+
+    Parameters
+    ----------
+    signal : psygnal.SignalInstance
+        The signal instance to test.
+    args : Any
+        The arguments to check for in the last emission of the signal.
+
+    Raises
+    ------
+    AssertionError
+        If the signal was not emitted or was emitted more than once or if the last
+        emission did not have the expected arguments.
+    """
+    with assert_emitted_once(signal) as mock:
+        yield mock
+        mock.assert_emitted_once_with(*args)
+
+
+@contextmanager
+def assert_ever_emitted_with(
+    signal: psygnal.SignalInstance, *args: Any
+) -> Iterator[SignalTester]:
+    """Assert that the signal was emitted *ever* with the given arguments.
+
+    Parameters
+    ----------
+    signal : psygnal.SignalInstance
+        The signal instance to test.
+    args : Any
+        The arguments to check for in any emission of the signal.
+
+    Raises
+    ------
+    AssertionError
+        If the signal was never emitted or if it was emitted but not with the expected
+        arguments.
+    """
+    with assert_emitted(signal) as mock:
+        yield mock
+        mock.assert_ever_emitted_with(*args)

--- a/tests/test_testing_utils.py
+++ b/tests/test_testing_utils.py
@@ -1,3 +1,5 @@
+import re
+
 import pytest
 
 import psygnal.testing as pt
@@ -9,11 +11,13 @@ class MyObject:
     value_changed = Signal(int)
 
 
-def test_assert_emitted():
+def test_assert_emitted() -> None:
     obj = MyObject()
 
-    with pt.assert_emitted(obj.changed):
+    with pt.assert_emitted(obj.changed) as tester:
         obj.changed.emit()
+
+    assert isinstance(tester, pt.SignalTester)
 
     with pytest.raises(
         AssertionError, match="Expected 'changed' to have been emitted."
@@ -21,10 +25,177 @@ def test_assert_emitted():
         with pt.assert_emitted(obj.changed):
             pass
 
-    with pt.assert_emitted_once(obj.changed):
-        obj.changed.emit()
 
-    with pytest.raises(AssertionError):
+def test_assert_emitted_once():
+    obj = MyObject()
+    with pt.assert_emitted_once(obj.changed) as tester:
+        obj.changed.emit()
+    assert isinstance(tester, pt.SignalTester)
+
+    with pytest.raises(
+        AssertionError,
+        match="Expected 'changed' to have been emitted once. Emitted 2 times.",
+    ):
         with pt.assert_emitted_once(obj.changed):
             obj.changed.emit()
             obj.changed.emit()
+
+
+def test_assert_not_emitted() -> None:
+    obj = MyObject()
+    with pt.assert_not_emitted(obj.changed) as tester:
+        pass
+
+    assert isinstance(tester, pt.SignalTester)
+
+    with pytest.raises(
+        AssertionError,
+        match="Expected 'changed' to not have been emitted. Emitted once.",
+    ):
+        with pt.assert_not_emitted(obj.changed):
+            obj.changed.emit()
+
+    with pytest.raises(
+        AssertionError,
+        match="Expected 'changed' to not have been emitted. Emitted 4 times.",
+    ):
+        with pt.assert_not_emitted(obj.changed):
+            obj.changed.emit()
+            obj.changed.emit()
+            obj.changed.emit()
+            obj.changed.emit()
+
+
+def test_assert_emitted_with() -> None:
+    obj = MyObject()
+    with pt.assert_emitted_with(obj.value_changed, 42) as tester:
+        obj.value_changed.emit(41)
+        obj.value_changed.emit(42)
+
+    assert isinstance(tester, pt.SignalTester)
+
+    with pytest.raises(
+        AssertionError,
+        match=re.escape(
+            "Expected 'value_changed' to have been emitted with arguments (42,)."
+            "\nActual: not emitted"
+        ),
+    ):
+        with pt.assert_emitted_with(obj.value_changed, 42):
+            pass
+
+    with pytest.raises(
+        AssertionError,
+        match=re.escape(
+            "Expected 'value_changed' to have been emitted with arguments (42,)."
+            "\nActual: (43,)"
+        ),
+    ):
+        with pt.assert_emitted_with(obj.value_changed, 42):
+            obj.value_changed.emit(42)
+            obj.value_changed.emit(43)
+
+
+def test_assert_emitted_once_with() -> None:
+    obj = MyObject()
+    with pt.assert_emitted_once_with(obj.value_changed, 42) as tester:
+        obj.value_changed.emit(42)
+
+    assert isinstance(tester, pt.SignalTester)
+
+    with pytest.raises(
+        AssertionError,
+        match=re.escape(
+            "Expected 'value_changed' to have been emitted exactly once. "
+            "Emitted 2 times."
+        ),
+    ):
+        with pt.assert_emitted_once_with(obj.value_changed, 42):
+            obj.value_changed.emit(42)
+            obj.value_changed.emit(42)
+
+    with pytest.raises(
+        AssertionError,
+        match=re.escape(
+            "Expected 'value_changed' to have been emitted once with arguments (42,)."
+            "\nActual: (43,)"
+        ),
+    ):
+        with pt.assert_emitted_once_with(obj.value_changed, 42):
+            obj.value_changed.emit(43)
+
+
+def test_assert_ever_emitted_with() -> None:
+    obj = MyObject()
+
+    with pt.assert_ever_emitted_with(obj.value_changed, 42) as tester:
+        obj.value_changed.emit(41)
+        obj.value_changed.emit(42)
+        obj.value_changed.emit(43)
+
+    assert isinstance(tester, pt.SignalTester)
+
+    with pytest.raises(
+        AssertionError,
+        match=re.escape(
+            "Expected 'value_changed' to have been emitted at least once with "
+            "arguments (42,)."
+            "\nActual: not emitted"
+        ),
+    ):
+        with pt.assert_ever_emitted_with(obj.value_changed, 42):
+            pass
+
+    with pytest.raises(
+        AssertionError,
+        match=re.escape(
+            "Expected 'value_changed' to have been emitted at least once with "
+            "arguments (42,)."
+            "\nActual: (43,)"
+        ),
+    ):
+        with pt.assert_ever_emitted_with(obj.value_changed, 42):
+            obj.value_changed.emit(43)
+
+    with pytest.raises(
+        AssertionError,
+        match=re.escape(
+            "Expected 'value_changed' to have been emitted at least once with "
+            "arguments (42,)."
+            "\nActual: [(41,), (42, 43)]"
+        ),
+    ):
+        with pt.assert_ever_emitted_with(obj.value_changed, 42):
+            obj.value_changed.emit(41)
+            obj.value_changed.emit(42, 43)
+
+
+def test_signal_tester() -> None:
+    obj = MyObject()
+    tester = pt.SignalTester(obj.changed)
+    tester.connect()
+    assert tester.signal_name == "changed"
+    assert tester.mock.call_count == 0
+
+    obj.changed.emit()
+
+    tester.assert_emitted_once()
+    tester.assert_emitted()
+    tester.assert_emitted_with()
+    assert tester.emit_count == 1
+    tester.reset()
+    assert tester.emit_count == 0
+
+    tester2 = pt.SignalTester(obj.value_changed)
+
+    with tester2:
+        obj.value_changed.emit(42)
+        obj.value_changed.emit(43)
+
+    tester2.assert_emitted()
+    tester2.assert_emitted_with(43)
+    tester2.assert_ever_emitted_with(42)
+
+    assert tester2.emit_args_list == [(42,), (43,)]
+    assert tester2.emit_count == 2
+    assert tester2.emit_args == (43,)

--- a/tests/test_testing_utils.py
+++ b/tests/test_testing_utils.py
@@ -1,0 +1,30 @@
+import pytest
+
+import psygnal.testing as pt
+from psygnal import Signal
+
+
+class MyObject:
+    changed = Signal()
+    value_changed = Signal(int)
+
+
+def test_assert_emitted():
+    obj = MyObject()
+
+    with pt.assert_emitted(obj.changed):
+        obj.changed.emit()
+
+    with pytest.raises(
+        AssertionError, match="Expected 'changed' to have been emitted."
+    ):
+        with pt.assert_emitted(obj.changed):
+            pass
+
+    with pt.assert_emitted_once(obj.changed):
+        obj.changed.emit()
+
+    with pytest.raises(AssertionError):
+        with pt.assert_emitted_once(obj.changed):
+            obj.changed.emit()
+            obj.changed.emit()


### PR DESCRIPTION
closes #46 (i think?  @Czaki?) by adding conveniences around testing with psygnal.

These are all synchronous tests, so they don't do anything like `waitSignal()` ... note that you can already *also* use `pytestqt` to call `waitSignal()` and wait for a psygnal Signal.  But this just removes a lot of boilerplate to test standard scenarios without having to use `Mock()`


```python
from psygnal import Signal
import psygnal.testing as pt

class MyObject:
    changed = Signal()
    value_changed = Signal(int)

def test_my_object():
    obj = MyObject()

    with pt.assert_emitted(obj.changed):
        obj.changed.emit()
    
    with pt.assert_not_emitted(obj.value_changed):
        obj.changed.emit()
    
    with pt.assert_emitted_once(obj.value_changed):
        obj.value_changed.emit(42)

    with pt.assert_emitted_once_with(obj.value_changed, 42):
        obj.value_changed.emit(42)

    with pt.assert_ever_emitted_with(obj.value_changed, 42):
        obj.value_changed.emit(41)
        obj.value_changed.emit(42)
        obj.value_changed.emit(43)
```


lots of docs added as well