### PR TITLE
fix: Fix leaking objects by `connect_child_events=True` in `SignalGroupDescriptor` 

### DIFF
--- a/src/psygnal/_group_descriptor.py
+++ b/src/psygnal/_group_descriptor.py
@@ -700,8 +700,9 @@ class SignalGroupDescriptor:
 
             # Register callback to connect child events on first connection if requested
             if self._connect_child_events:
+                ref_ = weakref.ref(instance)
                 grp._psygnal_relay._on_first_connect_callbacks.append(
-                    lambda: connect_child_events(instance, recurse=True, _group=grp)
+                    lambda: connect_child_events(ref_, recurse=True, _group=grp)
                 )
 
         return self._instance_map[obj_id]
@@ -769,6 +770,10 @@ def connect_child_events(
         The SignalGroup to connect to.  If not provided, will be found by calling
         `get_evented_namespace(obj)`. By default None.
     """
+    if isinstance(obj, weakref.ref):
+        obj = weakref.ref(obj)
+        if obj is None:
+            return
     if _group is None and (_group := _find_signal_group(obj)) is None:
         return  # pragma: no cover  # not evented
 

--- a/src/psygnal/_group_descriptor.py
+++ b/src/psygnal/_group_descriptor.py
@@ -700,7 +700,10 @@ class SignalGroupDescriptor:
 
             # Register callback to connect child events on first connection if requested
             if self._connect_child_events:
-                ref_ = weakref.ref(instance)
+                try:
+                    ref_ = weakref.ref(instance)
+                except TypeError:
+                    ref_ = instance  # type: ignore
                 grp._psygnal_relay._on_first_connect_callbacks.append(
                     lambda: connect_child_events(ref_, recurse=True, _group=grp)
                 )
@@ -771,7 +774,7 @@ def connect_child_events(
         `get_evented_namespace(obj)`. By default None.
     """
     if isinstance(obj, weakref.ref):
-        obj = weakref.ref(obj)
+        obj = obj()
         if obj is None:
             return
     if _group is None and (_group := _find_signal_group(obj)) is None:

--- a/src/psygnal/_group_descriptor.py
+++ b/src/psygnal/_group_descriptor.py
@@ -776,7 +776,7 @@ def connect_child_events(
     if isinstance(obj, weakref.ref):
         obj = obj()
         if obj is None:
-            return
+            return  # pragma: no cover
     if _group is None and (_group := _find_signal_group(obj)) is None:
         return  # pragma: no cover  # not evented
 


### PR DESCRIPTION
closes #406