### PR TITLE
chore: Limit mypy version and fix typesafety

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ test = [
     "anyio",
     "trio",
 ]
-test-typing = [{ include-group = "test-min" }, "pytest-mypy-plugins; python_version < '3.14'"]
+test-typing = [{ include-group = "test-min" }, "pytest-mypy-plugins<4; python_version < '3.14'"]
 testqt = [{ include-group = "test" }, "pytest-qt", "qtpy"]
 test-codspeed = [{ include-group = "test" }, "pytest-codspeed"]
 docs = [
@@ -103,7 +103,7 @@ enable-by-default = false
 require-runtime-dependencies = true
 dependencies = [
     "hatch-mypyc>=0.13.0",
-    "mypy",
+    "mypy<1.20",
     "mypy_extensions >=0.4.2",
     "pydantic!=2.10.0",        # typing error in v2.10 prevents mypyc from working
     "types-attrs",

--- a/typesafety/test_containers.yml
+++ b/typesafety/test_containers.yml
@@ -6,8 +6,8 @@
     elist.append(1)
     x = elist.pop()
 
-    reveal_type(elist)  # N: Revealed type is "psygnal.containers._evented_list.EventedList[builtins.int]"
-    reveal_type(x)  # N: Revealed type is "builtins.int"
+    reveal_type(elist)  # N: Revealed type is "psygnal.containers._evented_list.EventedList[int]"
+    reveal_type(x)  # N: Revealed type is "int"
 
 - case: evented_set_types
   main: |
@@ -17,5 +17,5 @@
     elist.add(1)
     x = elist.pop()
 
-    reveal_type(elist)  # N: Revealed type is "psygnal.containers._evented_set.EventedSet[builtins.int]"
-    reveal_type(x)  # N: Revealed type is "builtins.int"
+    reveal_type(elist)  # N: Revealed type is "psygnal.containers._evented_set.EventedSet[int]"
+    reveal_type(x)  # N: Revealed type is "int"

--- a/typesafety/test_group.yml
+++ b/typesafety/test_group.yml
@@ -19,10 +19,10 @@
     def func(x: int) -> None:
         pass
 
-    reveal_type(func)  # N: Revealed type is "def (x: builtins.int)"
+    reveal_type(func)  # N: Revealed type is "def (x: int)"
 
     @t.e.x.connect
     def func2(x: int) -> None:
         pass
 
-    reveal_type(func2)  # N: Revealed type is "def (x: builtins.int)"
+    reveal_type(func2)  # N: Revealed type is "def (x: int)"

--- a/typesafety/test_signal.yml
+++ b/typesafety/test_signal.yml
@@ -27,17 +27,17 @@
 
     def a(x: int, y: str) -> Any: ...
     x = s.connect(a)
-    reveal_type(x)  # N: Revealed type is "def (x: builtins.int, y: builtins.str) -> Any"
+    reveal_type(x)  # N: Revealed type is "def (x: int, y: str) -> Any"
 
     @s.connect
     def b(x: str) -> int: return 1
-    reveal_type(b)  # N: Revealed type is "def (x: builtins.str) -> builtins.int"
+    reveal_type(b)  # N: Revealed type is "def (x: str) -> int"
 
     def c(x: int, y: str) -> Any: ...
     y = s.connect(c, check_nargs=False)
-    reveal_type(y)  # N: Revealed type is "def (x: builtins.int, y: builtins.str) -> Any"
+    reveal_type(y)  # N: Revealed type is "def (x: int, y: str) -> Any"
 
     @s.connect(check_nargs=False)
     def d(x: str) -> None: ...
 
-    reveal_type(d)  # N: Revealed type is "def (x: builtins.str)"
+    reveal_type(d)  # N: Revealed type is "def (x: str)"

--- a/typesafety/test_utils.yml
+++ b/typesafety/test_utils.yml
@@ -6,8 +6,8 @@
       return True
 
     x = throttled(a)
-    reveal_type(x.__call__)  # N: Revealed type is "def (x: builtins.int, y: builtins.str)"
-    reveal_type(x)           # N: Revealed type is "psygnal._throttler.Throttler[[x: builtins.int, y: builtins.str]]"
+    reveal_type(x.__call__)  # N: Revealed type is "def (x: int, y: str)"
+    reveal_type(x)           # N: Revealed type is "psygnal._throttler.Throttler[[x: int, y: str]]"
 
 - case: debounced
   main: |
@@ -17,8 +17,8 @@
       return True
 
     x = debounced(a)
-    reveal_type(x.__call__)  # N: Revealed type is "def (x: builtins.int, y: builtins.str)"
-    reveal_type(x)           # N: Revealed type is "psygnal._throttler.Debouncer[[x: builtins.int, y: builtins.str]]"
+    reveal_type(x.__call__)  # N: Revealed type is "def (x: int, y: str)"
+    reveal_type(x)           # N: Revealed type is "psygnal._throttler.Debouncer[[x: int, y: str]]"
 
 - case: weak_callback
   main: |
@@ -28,6 +28,6 @@
       return True
 
     x = weak_callback(a)
-    reveal_type(x)           # N: Revealed type is "psygnal._weak_callback.WeakCallback[builtins.bool]"
-    reveal_type(x.cb)        # N: Revealed type is "def (args: builtins.tuple[Any, ...] =)"
-    reveal_type(x.__call__)  # N: Revealed type is "def (*args: Any, **kwds: Any) -> builtins.bool"
+    reveal_type(x)           # N: Revealed type is "psygnal._weak_callback.WeakCallback[bool]"
+    reveal_type(x.cb)        # N: Revealed type is "def (args: tuple[Any, ...] =)"
+    reveal_type(x.__call__)  # N: Revealed type is "def (*args: Any, **kwds: Any) -> bool"


### PR DESCRIPTION
extracted from #413 


It looks like psygnal is not compatible with most recent mypy versions. 

I do not understand this problem yet so send a patch to pin working version to unlock other PRs.