### PR TITLE
fix: Unpin mypy

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,7 +32,7 @@ repos:
 
   - repo: https://github.com/pre-commit/mirrors-mypy
     # this must match the mypy version in pyproject.toml
-    rev: v1.19.1
+    rev: v2.1.0
     hooks:
       - id: mypy
         exclude: tests|_throttler.pyi|_group.pyi

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,15 +68,15 @@ dev = [
     { include-group = "docs" },
     "PyQt6",
     "ipython",
-    "mypy",
+    "mypy >=2.1.0",
     "mypy_extensions",
-    "pre-commit",
     "asv",
     "ruff",
     "typing-extensions",
     "rich>=14.0.0",
     "pdbpp; sys_platform != 'win32'",
     "pytest-benchmark>=5.1.0",
+    "prek>=0.4.3",
 ]
 
 [project.urls]
@@ -103,7 +103,7 @@ enable-by-default = false
 require-runtime-dependencies = true
 dependencies = [
     "hatch-mypyc>=0.13.0",
-    "mypy<1.20",
+    "mypy >=2.1.0",
     "mypy_extensions >=0.4.2",
     "pydantic!=2.10.0",        # typing error in v2.10 prevents mypyc from working
     "types-attrs",

--- a/src/psygnal/_signal.py
+++ b/src/psygnal/_signal.py
@@ -827,7 +827,7 @@ class SignalInstance:
         elif isinstance(slot, int):
             self._slots.pop(slot)
         else:
-            self._slots.remove(cast("WeakCallback", slot))
+            self._slots.remove(slot)
 
     def _try_discard(self, callback: WeakCallback, missing_ok: bool = True) -> None:
         """Try to discard a callback from the list of slots.
@@ -1809,10 +1809,11 @@ def _ridiculously_call_emit(emitter: Any) -> str | None:  # pragma: no cover
     return None  # pragma: no cover
 
 
-_compiled: bool
-
-
-def __getattr__(name: str) -> Any:
-    if name == "_compiled":
-        return hasattr(Signal, "__mypyc_attrs__")
-    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+# NOTE: this MUST be a module-level assignment rather than a module-level
+# `__getattr__`.  When mypyc compiles a module-level `__getattr__` (supported
+# since mypy 1.20), the native import machinery invokes it while setting up the
+# module's dunder attributes (e.g. `__package__`) *before* the module body has
+# run, which sends `__getattr__` into infinite recursion and segfaults on
+# import.  See:
+# https://github.com/pyapp-kit/psygnal/issues/414
+_compiled: bool = hasattr(Signal, "__mypyc_attrs__")


### PR DESCRIPTION
fixes #414 

claude figured this out, not me.  the fix is trivial (just not using a module level getattr)... but I can't say I understand why.    Claude did a git bisect on mypy and says its https://github.com/python/mypy/pull/21101 that caused it (rewrote how a native module imports another native module compiled in the same group).  and gives as an example:

```python
# _a.py
from typing import Any
X = 42
def __getattr__(name: str) -> Any:
    raise AttributeError(name)
#  _b.py
from _a import X
def get_x() -> int:
    return X
```

Compile both together with mypyc _a.py _b.py, then import _b.   mypy 1.19 works, mypy 1.20 segfaults.

I can't say I understand exactly what happened in mypyc, but I also don't care enough about the difference of using a module level `__getattr__`.