### PR TITLE
feat: Add batch signal support for contiguous item insertions and removals in EventedList

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -98,9 +98,9 @@ jobs:
     uses: pyapp-kit/workflows/.github/workflows/test-dependents.yml@main
     with:
       dependency-repo: pyapp-kit/magicgui
-      dependency-group: "pyside2"
-      qt: "pyside2"
-      python-version: "3.10"
+      dependency-group: "pyside6"
+      qt: "pyside6"
+      python-version: "3.12"
 
   typing:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -105,6 +105,14 @@ my_list.events.removed.connect(lambda i, val: print(f"Removed {val} at index {i}
 
 my_list.append(6)  # Output: Inserted 6 at index 5
 my_list.pop()  # Output: Removed 6 at index 5
+
+# the `items_*` signals bracket a contiguous batch with a single (start, stop) range,
+# so e.g. `extend` emits `items_inserting`/`items_inserted` once
+# while `inserted` still fires once per item.
+my_list.events.items_inserting.connect(
+    lambda start, stop: print(f"Inserting rows [{start}:{stop}]")
+)
+my_list.extend([7, 8, 9])  # Output: Inserting rows [2:5] (+ 3 per-item Inserted lines)
 ```
 
 See the

--- a/README.md
+++ b/README.md
@@ -107,9 +107,9 @@ my_list.append(6)  # Output: Inserted 6 at index 5
 my_list.pop()  # Output: Removed 6 at index 5
 
 # the `items_*` signals bracket a contiguous batch with a single (start, stop) range,
-# so e.g. `extend` emits `items_inserting`/`items_inserted` once
+# so e.g. `extend` emits `batch_inserting`/`batch_inserted` once
 # while `inserted` still fires once per item.
-my_list.events.items_inserting.connect(
+my_list.events.batch_inserting.connect(
     lambda start, stop: print(f"Inserting rows [{start}:{stop}]")
 )
 my_list.extend([7, 8, 9])  # Output: Inserting rows [2:5] (+ 3 per-item Inserted lines)

--- a/README.md
+++ b/README.md
@@ -106,13 +106,13 @@ my_list.events.removed.connect(lambda i, val: print(f"Removed {val} at index {i}
 my_list.append(6)  # Output: Inserted 6 at index 5
 my_list.pop()  # Output: Removed 6 at index 5
 
-# the `items_*` signals bracket a contiguous batch with a single (start, stop) range,
+# the `batch_*` signals bracket a contiguous batch with a single (start, stop) range,
 # so e.g. `extend` emits `batch_inserting`/`batch_inserted` once
 # while `inserted` still fires once per item.
 my_list.events.batch_inserting.connect(
     lambda start, stop: print(f"Inserting rows [{start}:{stop}]")
 )
-my_list.extend([7, 8, 9])  # Output: Inserting rows [2:5] (+ 3 per-item Inserted lines)
+my_list.extend([7, 8, 9])  # Output: Inserting rows [5:8] (+ 3 per-item Inserted lines)
 ```
 
 See the

--- a/docs/guides/dataclasses.md
+++ b/docs/guides/dataclasses.md
@@ -523,7 +523,7 @@ project = Project()
 project.events.connect(lambda info: print(f"{info.signal.name}: {info.args} {info.path}"))
 
 # Add a person to the list - EventedList emits the per-item events, bracketed by the
-# contiguous-range items_* events (useful for batch updates, e.g. driving a Qt model):
+# contiguous-range items_* events (useful for handling a batch as a single update):
 project.team_members.append(Person(name="Bob"))
 # items_inserting: (0, 1) (.team_members, [0])
 # inserting: (0,) (.team_members, [0])

--- a/docs/guides/dataclasses.md
+++ b/docs/guides/dataclasses.md
@@ -525,10 +525,10 @@ project.events.connect(lambda info: print(f"{info.signal.name}: {info.args} {inf
 # Add a person to the list - EventedList emits the per-item events, bracketed by the
 # contiguous-range items_* events (useful for handling a batch as a single update):
 project.team_members.append(Person(name="Bob"))
-# items_inserting: (0, 1) (.team_members, [0])
+# batch_inserting: (0, 1) (.team_members, [0])
 # inserting: (0,) (.team_members, [0])
 # inserted: (0, Person(name='Bob', age=0)) (.team_members, [0])
-# items_inserted: (0, 1, [Person(name='Bob', age=0)]) (.team_members, [0])
+# batch_inserted: (0, 1, [Person(name='Bob', age=0)]) (.team_members, [0])
 
 # Change a person in the list - this also bubbles up
 project.team_members[0].age = 25

--- a/docs/guides/dataclasses.md
+++ b/docs/guides/dataclasses.md
@@ -522,10 +522,13 @@ class Project:
 project = Project()
 project.events.connect(lambda info: print(f"{info.signal.name}: {info.args} {info.path}"))
 
-# Add a person to the list - EventedList emits two events here:
+# Add a person to the list - EventedList emits the per-item events, bracketed by the
+# contiguous-range items_* events (useful for batch updates, e.g. driving a Qt model):
 project.team_members.append(Person(name="Bob"))
+# items_inserting: (0, 1) (.team_members, [0])
 # inserting: (0,) (.team_members, [0])
 # inserted: (0, Person(name='Bob', age=0)) (.team_members, [0])
+# items_inserted: (0, 1, [Person(name='Bob', age=0)]) (.team_members, [0])
 
 # Change a person in the list - this also bubbles up
 project.team_members[0].age = 25

--- a/docs/guides/dataclasses.md
+++ b/docs/guides/dataclasses.md
@@ -523,7 +523,7 @@ project = Project()
 project.events.connect(lambda info: print(f"{info.signal.name}: {info.args} {info.path}"))
 
 # Add a person to the list - EventedList emits the per-item events, bracketed by the
-# contiguous-range items_* events (useful for handling a batch as a single update):
+# contiguous-range batch_* events (useful for handling a batch as a single update):
 project.team_members.append(Person(name="Bob"))
 # batch_inserting: (0, 1) (.team_members, [0])
 # inserting: (0,) (.team_members, [0])

--- a/src/psygnal/containers/_evented_list.py
+++ b/src/psygnal/containers/_evented_list.py
@@ -20,6 +20,11 @@ All of the additional list-like methods are provided by the MutableSequence
 interface, and call one of those 4 methods.  So if you override a method, you
 MUST make sure that all the appropriate events are emitted.  (Tests should
 cover this in test_evented_list.py)
+
+`extend` and `clear` *are* re-implemented here, but only to bracket the whole
+operation with a single `batch_*` (start, stop) range.  They still funnel every
+item through `insert` / `__delitem__`, so the rule above is preserved: overriding
+`insert` or `__delitem__` remains sufficient to see every mutation.
 """
 
 from __future__ import annotations
@@ -99,20 +104,31 @@ class ListEvents(SignalGroup):
 
     This brackets the per-item `inserting` events (which still fire for each item), so
     that a batch insert (e.g. `extend`/`+=`) can be handled with a single update. A
-    single insert is just a length-1 range."""
+    single insert is just a length-1 range.
+
+    Note that the `batch_*` signals track *structural* changes only; slice assignment
+    (`el[a:b] = ...`) may change the length of the list but emits only `changed`."""
     batch_inserted = ListSignal(int, int, object)
     """`(start, stop, values)` emitted once after a contiguous block of items has been
     inserted into the half-open range `[start, stop)` (`values` is the inserted
-    `list`)."""
+    `list`).
+
+    `insert` always pairs this with its `batch_inserting`. `extend` does too, unless
+    `_pre_insert` rejects a value part way through the batch, in which case the
+    exception propagates and the batch is left unterminated (the list is partially
+    extended, as it is without the batch signals)."""
     batch_removing = ListSignal(int, int)
     """`(start, stop)` emitted once before a contiguous block of items is removed from
     the half-open range `[start, stop)`.
 
     Brackets the per-item `removing` events. Non-contiguous removals (e.g. a strided
-    slice) emit this once per contiguous block, highest block first."""
+    slice) emit this once per contiguous block, highest block first.
+
+    As with `batch_inserting`, slice assignment emits only `changed`."""
     batch_removed = ListSignal(int, int, object)
     """`(start, stop, values)` emitted once after a contiguous block of items has been
-    removed from the half-open range `[start, stop)` (`values` is the removed `list`).
+    removed from the half-open range `[start, stop)` (`values` is the removed `list`,
+    in list order, even though items are popped highest-index first).
     """
     moving = ListSignal(int, int)
     """`(index, new_index)` emitted before an item is moved from `index` to
@@ -170,6 +186,8 @@ class EventedList(MutableSequence[_T]):
         self._data: list[_T] = []
         self._hashable = hashable
         self._child_events = child_events
+        # >0 while extend() is bracketing a batch, so insert() doesn't emit its own
+        self._batch_depth = 0
         self.events = ListEvents(instance=self)
         self.extend(data)
 
@@ -182,32 +200,50 @@ class EventedList(MutableSequence[_T]):
 
     def insert(self, index: int, value: _T) -> None:
         """Insert `value` before index."""
+        # `_pre_insert` may reject the value; run it before emitting anything so a
+        # rejected value never leaves an unterminated batch_inserting behind.
+        _value = self._pre_insert(value)
+        if self._batch_depth:
+            # inside extend(), which brackets the whole batch itself
+            self._insert_one(index, value, _value)
+            return
         # normalize for the (range-aware) batch_* signals; the per-item events
         # keep emitting the raw `index` exactly as before.
         norm = max(0, len(self) + index) if index < 0 else min(index, len(self))
-        self.events.batch_inserting.emit(norm, norm + 1)
-        self._insert_one(index, value)
-        self.events.batch_inserted.emit(norm, norm + 1, [value])
+        if self.events.batch_inserting:
+            self.events.batch_inserting.emit(norm, norm + 1)
+        self._insert_one(index, value, _value)
+        if self.events.batch_inserted:
+            self.events.batch_inserted.emit(norm, norm + 1, [value])
 
     def extend(self, values: Iterable[_T]) -> None:
-        """Extend list by appending all items from `values`."""
+        """Extend list by appending all items from `values`.
+
+        Overrides `MutableSequence.extend` (which appends one at a time) so the whole
+        batch is bracketed by a single `batch_inserting`/`batch_inserted` pair. Items
+        still go through `insert` one by one, emitting the per-item events.
+        """
         values = list(values)
         if not values:
             return
         start, stop = len(self), len(self) + len(values)
-        self.events.batch_inserting.emit(start, stop)
-        for i, value in enumerate(values):
-            self._insert_one(start + i, value)
-        self.events.batch_inserted.emit(start, stop, values)
+        if self.events.batch_inserting:
+            self.events.batch_inserting.emit(start, stop)
+        self._batch_depth += 1
+        try:
+            for i, value in enumerate(values):
+                self.insert(start + i, value)
+        finally:
+            self._batch_depth -= 1
+        if self.events.batch_inserted:
+            self.events.batch_inserted.emit(start, stop, values)
 
-    def _insert_one(self, index: int, value: _T) -> None:
-        """Insert a single `value`, emitting the per-item `inserting`/`inserted`.
+    def _insert_one(self, index: int, value: _T, _value: _T) -> None:
+        """Insert `_value` (the `_pre_insert` result), emitting the per-item events.
 
-        This is the per-item primitive that `insert`/`extend` funnel through; the
-        contiguous-range `batch_inserting`/`batch_inserted` events are emitted by the
-        callers, bracketing one or more `_insert_one` calls.
+        `value` is the original, un-transformed object; it is what the `inserted`
+        event and `_post_insert` receive.
         """
-        _value = self._pre_insert(value)
         self.events.inserting.emit(index)
         self._data.insert(index, _value)
         self.events.inserted.emit(index, value)
@@ -218,8 +254,8 @@ class EventedList(MutableSequence[_T]):
 
         Overrides `MutableSequence.clear` (which pops one at a time) so the whole
         list is removed as a single contiguous block (one `batch_removing`/
-        `batch_removed` pair). The per-item `removing`/`removed` events still fire for
-        each item, highest index first, exactly as before.
+        `batch_removed` pair). Items still go through `__delitem__`, so the per-item
+        `removing`/`removed` events fire for each, highest index first, as before.
         """
         if self._data:
             del self[:]
@@ -271,14 +307,18 @@ class EventedList(MutableSequence[_T]):
             # still emitting the per-item removing/removed events (highest index
             # first, so lower indices stay valid as we go).
             for start, stop in _contiguous_runs(indices):
-                parent.events.batch_removing.emit(start, stop)
+                if parent.events.batch_removing:
+                    parent.events.batch_removing.emit(start, stop)
                 items: list[_T] = []
                 for index in range(stop - 1, start - 1, -1):
                     parent.events.removing.emit(index)
                     parent._pre_remove(index)
-                    items.insert(0, parent._data.pop(index))
-                    parent.events.removed.emit(index, items[0])
-                parent.events.batch_removed.emit(start, stop, items)
+                    item = parent._data.pop(index)
+                    items.append(item)
+                    parent.events.removed.emit(index, item)
+                if parent.events.batch_removed:
+                    items.reverse()  # popped highest-first; report in list order
+                    parent.events.batch_removed.emit(start, stop, items)
 
     def _delitem_indices(self, key: Index) -> Iterable[tuple[EventedList[_T], int]]:
         # returning (self, int) allows subclasses to pass nested members

--- a/src/psygnal/containers/_evented_list.py
+++ b/src/psygnal/containers/_evented_list.py
@@ -174,6 +174,9 @@ class EventedList(MutableSequence[_T]):
 
     events: ListEvents  # pragma: no cover
     _psygnal_group_: ClassVar[str] = "events"
+    # >0 while extend() is bracketing a batch, so insert() doesn't emit its own.
+    # (class-level default so instances unpickled from older versions still work)
+    _batch_depth: int = 0
 
     def __init__(
         self,
@@ -186,8 +189,6 @@ class EventedList(MutableSequence[_T]):
         self._data: list[_T] = []
         self._hashable = hashable
         self._child_events = child_events
-        # >0 while extend() is bracketing a batch, so insert() doesn't emit its own
-        self._batch_depth = 0
         self.events = ListEvents(instance=self)
         self.extend(data)
 
@@ -231,8 +232,8 @@ class EventedList(MutableSequence[_T]):
             self.events.batch_inserting.emit(start, stop)
         self._batch_depth += 1
         try:
-            for i, value in enumerate(values):
-                self.insert(start + i, value)
+            for value in values:
+                self.append(value)
         finally:
             self._batch_depth -= 1
         if self.events.batch_inserted:
@@ -323,6 +324,8 @@ class EventedList(MutableSequence[_T]):
     def _delitem_indices(self, key: Index) -> Iterable[tuple[EventedList[_T], int]]:
         # returning (self, int) allows subclasses to pass nested members
         if isinstance(key, int):
+            if not -len(self) <= key < len(self):
+                raise IndexError("list assignment index out of range")
             yield (self, key if key >= 0 else key + len(self))
         elif isinstance(key, slice):
             yield from ((self, i) for i in range(*key.indices(len(self))))

--- a/src/psygnal/containers/_evented_list.py
+++ b/src/psygnal/containers/_evented_list.py
@@ -99,23 +99,21 @@ class ListEvents(SignalGroup):
 
     This brackets the per-item `inserting` events (which still fire for each item), so
     that a batch insert (e.g. `extend`/`+=`) can be handled with a single update. A
-    single insert is just a length-1 range. Maps directly onto Qt's
-    `beginInsertRows(parent, start, stop - 1)`."""
+    single insert is just a length-1 range."""
     items_inserted = ListSignal(int, int, object)
     """`(start, stop, values)` emitted once after a contiguous block of items has been
     inserted into the half-open range `[start, stop)` (`values` is the inserted
-    `list`). Maps onto Qt's `endInsertRows()`."""
+    `list`)."""
     items_removing = ListSignal(int, int)
     """`(start, stop)` emitted once before a contiguous block of items is removed from
     the half-open range `[start, stop)`.
 
     Brackets the per-item `removing` events. Non-contiguous removals (e.g. a strided
-    slice) emit this once per contiguous block, highest block first. Maps directly onto
-    Qt's `beginRemoveRows(parent, start, stop - 1)`."""
+    slice) emit this once per contiguous block, highest block first."""
     items_removed = ListSignal(int, int, object)
     """`(start, stop, values)` emitted once after a contiguous block of items has been
     removed from the half-open range `[start, stop)` (`values` is the removed `list`).
-    Maps onto Qt's `endRemoveRows()`."""
+    """
     moving = ListSignal(int, int)
     """`(index, new_index)` emitted before an item is moved from `index` to
     `new_index`"""

--- a/src/psygnal/containers/_evented_list.py
+++ b/src/psygnal/containers/_evented_list.py
@@ -93,24 +93,24 @@ class ListEvents(SignalGroup):
     """`(index)` emitted before an item is removed at `index`"""
     removed = ListSignal(int, object)
     """`(index, value)` emitted after `value` is removed at `index`"""
-    items_inserting = ListSignal(int, int)
+    batch_inserting = ListSignal(int, int)
     """`(start, stop)` emitted once before a contiguous block of items is inserted
     into the half-open range `[start, stop)`.
 
     This brackets the per-item `inserting` events (which still fire for each item), so
     that a batch insert (e.g. `extend`/`+=`) can be handled with a single update. A
     single insert is just a length-1 range."""
-    items_inserted = ListSignal(int, int, object)
+    batch_inserted = ListSignal(int, int, object)
     """`(start, stop, values)` emitted once after a contiguous block of items has been
     inserted into the half-open range `[start, stop)` (`values` is the inserted
     `list`)."""
-    items_removing = ListSignal(int, int)
+    batch_removing = ListSignal(int, int)
     """`(start, stop)` emitted once before a contiguous block of items is removed from
     the half-open range `[start, stop)`.
 
     Brackets the per-item `removing` events. Non-contiguous removals (e.g. a strided
     slice) emit this once per contiguous block, highest block first."""
-    items_removed = ListSignal(int, int, object)
+    batch_removed = ListSignal(int, int, object)
     """`(start, stop, values)` emitted once after a contiguous block of items has been
     removed from the half-open range `[start, stop)` (`values` is the removed `list`).
     """
@@ -182,12 +182,12 @@ class EventedList(MutableSequence[_T]):
 
     def insert(self, index: int, value: _T) -> None:
         """Insert `value` before index."""
-        # normalize for the (range-aware) items_* signals; the per-item events
+        # normalize for the (range-aware) batch_* signals; the per-item events
         # keep emitting the raw `index` exactly as before.
         norm = max(0, len(self) + index) if index < 0 else min(index, len(self))
-        self.events.items_inserting.emit(norm, norm + 1)
+        self.events.batch_inserting.emit(norm, norm + 1)
         self._insert_one(index, value)
-        self.events.items_inserted.emit(norm, norm + 1, [value])
+        self.events.batch_inserted.emit(norm, norm + 1, [value])
 
     def extend(self, values: Iterable[_T]) -> None:
         """Extend list by appending all items from `values`."""
@@ -195,16 +195,16 @@ class EventedList(MutableSequence[_T]):
         if not values:
             return
         start, stop = len(self), len(self) + len(values)
-        self.events.items_inserting.emit(start, stop)
+        self.events.batch_inserting.emit(start, stop)
         for i, value in enumerate(values):
             self._insert_one(start + i, value)
-        self.events.items_inserted.emit(start, stop, values)
+        self.events.batch_inserted.emit(start, stop, values)
 
     def _insert_one(self, index: int, value: _T) -> None:
         """Insert a single `value`, emitting the per-item `inserting`/`inserted`.
 
         This is the per-item primitive that `insert`/`extend` funnel through; the
-        contiguous-range `items_inserting`/`items_inserted` events are emitted by the
+        contiguous-range `batch_inserting`/`batch_inserted` events are emitted by the
         callers, bracketing one or more `_insert_one` calls.
         """
         _value = self._pre_insert(value)
@@ -217,8 +217,8 @@ class EventedList(MutableSequence[_T]):
         """Remove all items from the list.
 
         Overrides `MutableSequence.clear` (which pops one at a time) so the whole
-        list is removed as a single contiguous block (one `items_removing`/
-        `items_removed` pair). The per-item `removing`/`removed` events still fire for
+        list is removed as a single contiguous block (one `batch_removing`/
+        `batch_removed` pair). The per-item `removing`/`removed` events still fire for
         each item, highest index first, exactly as before.
         """
         if self._data:
@@ -267,18 +267,18 @@ class EventedList(MutableSequence[_T]):
             by_parent.setdefault(id(parent), (parent, []))[1].append(index)
 
         for parent, indices in by_parent.values():
-            # bracket each contiguous block with items_removing/items_removed, while
+            # bracket each contiguous block with batch_removing/batch_removed, while
             # still emitting the per-item removing/removed events (highest index
             # first, so lower indices stay valid as we go).
             for start, stop in _contiguous_runs(indices):
-                parent.events.items_removing.emit(start, stop)
+                parent.events.batch_removing.emit(start, stop)
                 items: list[_T] = []
                 for index in range(stop - 1, start - 1, -1):
                     parent.events.removing.emit(index)
                     parent._pre_remove(index)
                     items.insert(0, parent._data.pop(index))
                     parent.events.removed.emit(index, items[0])
-                parent.events.items_removed.emit(start, stop, items)
+                parent.events.batch_removed.emit(start, stop, items)
 
     def _delitem_indices(self, key: Index) -> Iterable[tuple[EventedList[_T], int]]:
         # returning (self, int) allows subclasses to pass nested members

--- a/src/psygnal/containers/_evented_list.py
+++ b/src/psygnal/containers/_evented_list.py
@@ -49,6 +49,25 @@ _T = TypeVar("_T")
 Index: TypeAlias = int | slice
 
 
+def _contiguous_runs(indices: Iterable[int]) -> Iterable[tuple[int, int]]:
+    """Yield `(start, stop)` half-open runs of contiguous integers, highest first.
+
+    e.g. `[1, 2, 3, 5, 6]` -> `(5, 7)`, `(1, 4)`.  Runs are yielded in descending
+    order so that deleting later (higher) blocks leaves earlier indices valid.
+    """
+    ordered = sorted(set(indices), reverse=True)
+    if not ordered:
+        return
+    stop = ordered[0] + 1
+    prev = ordered[0]
+    for idx in ordered[1:]:
+        if idx != prev - 1:
+            yield prev, stop
+            stop = idx + 1
+        prev = idx
+    yield prev, stop
+
+
 class ListSignalInstance(SignalInstance):
     def _psygnal_relocate_info_(self, emission_info: EmissionInfo) -> EmissionInfo:
         """Relocate the emission info to the index being modified.
@@ -74,6 +93,29 @@ class ListEvents(SignalGroup):
     """`(index)` emitted before an item is removed at `index`"""
     removed = ListSignal(int, object)
     """`(index, value)` emitted after `value` is removed at `index`"""
+    items_inserting = ListSignal(int, int)
+    """`(start, stop)` emitted once before a contiguous block of items is inserted
+    into the half-open range `[start, stop)`.
+
+    This brackets the per-item `inserting` events (which still fire for each item), so
+    that a batch insert (e.g. `extend`/`+=`) can be handled with a single update. A
+    single insert is just a length-1 range. Maps directly onto Qt's
+    `beginInsertRows(parent, start, stop - 1)`."""
+    items_inserted = ListSignal(int, int, object)
+    """`(start, stop, values)` emitted once after a contiguous block of items has been
+    inserted into the half-open range `[start, stop)` (`values` is the inserted
+    `list`). Maps onto Qt's `endInsertRows()`."""
+    items_removing = ListSignal(int, int)
+    """`(start, stop)` emitted once before a contiguous block of items is removed from
+    the half-open range `[start, stop)`.
+
+    Brackets the per-item `removing` events. Non-contiguous removals (e.g. a strided
+    slice) emit this once per contiguous block, highest block first. Maps directly onto
+    Qt's `beginRemoveRows(parent, start, stop - 1)`."""
+    items_removed = ListSignal(int, int, object)
+    """`(start, stop, values)` emitted once after a contiguous block of items has been
+    removed from the half-open range `[start, stop)` (`values` is the removed `list`).
+    Maps onto Qt's `endRemoveRows()`."""
     moving = ListSignal(int, int)
     """`(index, new_index)` emitted before an item is moved from `index` to
     `new_index`"""
@@ -142,11 +184,47 @@ class EventedList(MutableSequence[_T]):
 
     def insert(self, index: int, value: _T) -> None:
         """Insert `value` before index."""
+        # normalize for the (range-aware) items_* signals; the per-item events
+        # keep emitting the raw `index` exactly as before.
+        norm = max(0, len(self) + index) if index < 0 else min(index, len(self))
+        self.events.items_inserting.emit(norm, norm + 1)
+        self._insert_one(index, value)
+        self.events.items_inserted.emit(norm, norm + 1, [value])
+
+    def extend(self, values: Iterable[_T]) -> None:
+        """Extend list by appending all items from `values`."""
+        values = list(values)
+        if not values:
+            return
+        start, stop = len(self), len(self) + len(values)
+        self.events.items_inserting.emit(start, stop)
+        for i, value in enumerate(values):
+            self._insert_one(start + i, value)
+        self.events.items_inserted.emit(start, stop, values)
+
+    def _insert_one(self, index: int, value: _T) -> None:
+        """Insert a single `value`, emitting the per-item `inserting`/`inserted`.
+
+        This is the per-item primitive that `insert`/`extend` funnel through; the
+        contiguous-range `items_inserting`/`items_inserted` events are emitted by the
+        callers, bracketing one or more `_insert_one` calls.
+        """
         _value = self._pre_insert(value)
         self.events.inserting.emit(index)
         self._data.insert(index, _value)
         self.events.inserted.emit(index, value)
         self._post_insert(value)
+
+    def clear(self) -> None:
+        """Remove all items from the list.
+
+        Overrides `MutableSequence.clear` (which pops one at a time) so the whole
+        list is removed as a single contiguous block (one `items_removing`/
+        `items_removed` pair). The per-item `removing`/`removed` events still fire for
+        each item, highest index first, exactly as before.
+        """
+        if self._data:
+            del self[:]
 
     @overload
     def __getitem__(self, key: int) -> _T: ...
@@ -185,12 +263,24 @@ class EventedList(MutableSequence[_T]):
 
     def __delitem__(self, key: Index) -> None:
         """Delete self[key]."""
-        # delete from the end
-        for parent, index in sorted(self._delitem_indices(key), reverse=True):
-            parent.events.removing.emit(index)
-            parent._pre_remove(index)
-            item = parent._data.pop(index)
-            self.events.removed.emit(index, item)
+        # group indices by their (possibly nested) parent list
+        by_parent: dict[int, tuple[EventedList[_T], list[int]]] = {}
+        for parent, index in self._delitem_indices(key):
+            by_parent.setdefault(id(parent), (parent, []))[1].append(index)
+
+        for parent, indices in by_parent.values():
+            # bracket each contiguous block with items_removing/items_removed, while
+            # still emitting the per-item removing/removed events (highest index
+            # first, so lower indices stay valid as we go).
+            for start, stop in _contiguous_runs(indices):
+                parent.events.items_removing.emit(start, stop)
+                items: list[_T] = []
+                for index in range(stop - 1, start - 1, -1):
+                    parent.events.removing.emit(index)
+                    parent._pre_remove(index)
+                    items.insert(0, parent._data.pop(index))
+                    parent.events.removed.emit(index, items[0])
+                parent.events.items_removed.emit(start, stop, items)
 
     def _delitem_indices(self, key: Index) -> Iterable[tuple[EventedList[_T], int]]:
         # returning (self, int) allows subclasses to pass nested members

--- a/src/psygnal/containers/_selectable_evented_list.py
+++ b/src/psygnal/containers/_selectable_evented_list.py
@@ -51,9 +51,9 @@ class SelectableEventedList(Selectable[_T], EventedList[_T]):
     def _on_item_removed(self, idx: int, obj: Any) -> None:
         self.selection.discard(obj)
 
-    def insert(self, index: int, value: _T) -> None:
-        """Insert item(s) into the list and update the selection."""
-        super().insert(index, value)
+    def _insert_one(self, index: int, value: _T) -> None:
+        """Insert an item into the list and update the selection."""
+        super()._insert_one(index, value)
         if self._activate_on_insert:
             self.selection.active = value
 

--- a/src/psygnal/containers/_selectable_evented_list.py
+++ b/src/psygnal/containers/_selectable_evented_list.py
@@ -51,9 +51,9 @@ class SelectableEventedList(Selectable[_T], EventedList[_T]):
     def _on_item_removed(self, idx: int, obj: Any) -> None:
         self.selection.discard(obj)
 
-    def _insert_one(self, index: int, value: _T) -> None:
-        """Insert an item into the list and update the selection."""
-        super()._insert_one(index, value)
+    def insert(self, index: int, value: _T) -> None:
+        """Insert item(s) into the list and update the selection."""
+        super().insert(index, value)
         if self._activate_on_insert:
             self.selection.active = value
 

--- a/tests/containers/test_evented_list.py
+++ b/tests/containers/test_evented_list.py
@@ -24,14 +24,14 @@ def test_list(regular_list):
 
 
 # per-item events bracketed by the contiguous-block items_* events
-INSERT = ("items_inserting", "inserting", "inserted", "items_inserted")
-REMOVE = ("items_removing", "removing", "removed", "items_removed")
+INSERT = ("batch_inserting", "inserting", "inserted", "batch_inserted")
+REMOVE = ("batch_removing", "removing", "removed", "batch_removed")
 
 
 def _remove_block(n: int) -> tuple[str, ...]:
     # one contiguous block of N removals:
-    # items_removing, (removing, removed)*N, items_removed
-    return ("items_removing", *(("removing", "removed") * n), "items_removed")
+    # batch_removing, (removing, removed)*N, batch_removed
+    return ("batch_removing", *(("removing", "removed") * n), "batch_removed")
 
 
 REMOVE_BLOCK2 = _remove_block(2)
@@ -61,7 +61,7 @@ REMOVE_BLOCK2 = _remove_block(2)
         (
             "extend",
             ([7, 8, 9],),
-            ("items_inserting", *(("inserting", "inserted") * 3), "items_inserted"),
+            ("batch_inserting", *(("inserting", "inserted") * 3), "batch_inserted"),
         ),
         ("index", (3,), ()),
         ("pop", (-2,), REMOVE),
@@ -71,7 +71,7 @@ REMOVE_BLOCK2 = _remove_block(2)
         (
             "__iadd__",
             ([7, 9],),
-            ("items_inserting", *(("inserting", "inserted") * 2), "items_inserted"),
+            ("batch_inserting", *(("inserting", "inserted") * 2), "batch_inserted"),
         ),
         ("__radd__", ([7, 9],), ()),  # does not mutate self
         # sort?
@@ -331,18 +331,18 @@ def test_child_events():
     assert root == [e_obj]
     e_obj.test.emit("hi")
 
-    # items_inserting + inserting + inserted + items_inserted + the child event
+    # batch_inserting + inserting + inserted + batch_inserted + the child event
     assert mock.call_count == 5
 
     expected = [
         call(
-            EmissionInfo(root.events.items_inserting, (0, 1), path=(PathStep(index=0),))
+            EmissionInfo(root.events.batch_inserting, (0, 1), path=(PathStep(index=0),))
         ),
         call(EmissionInfo(root.events.inserting, (0,), path=(PathStep(index=0),))),
         call(EmissionInfo(root.events.inserted, (0, e_obj), path=(PathStep(index=0),))),
         call(
             EmissionInfo(
-                root.events.items_inserted, (0, 1, [e_obj]), path=(PathStep(index=0),)
+                root.events.batch_inserted, (0, 1, [e_obj]), path=(PathStep(index=0),)
             )
         ),
         call(
@@ -378,10 +378,10 @@ def test_child_events_groups():
     e_obj.events.test2.emit("hi")
 
     assert [c[0][0].signal.name for c in mock.call_args_list] == [
-        "items_inserting",
+        "batch_inserting",
         "inserting",
         "inserted",
-        "items_inserted",
+        "batch_inserted",
         "test2",  # This is now the direct child signal, not child_event
     ]
 
@@ -389,13 +389,13 @@ def test_child_events_groups():
     # will also be detected, and the child event will be emitted directly with path info
     expected = [
         call(
-            EmissionInfo(root.events.items_inserting, (0, 1), path=(PathStep(index=0),))
+            EmissionInfo(root.events.batch_inserting, (0, 1), path=(PathStep(index=0),))
         ),
         call(EmissionInfo(root.events.inserting, (0,), path=(PathStep(index=0),))),
         call(EmissionInfo(root.events.inserted, (0, e_obj), path=(PathStep(index=0),))),
         call(
             EmissionInfo(
-                root.events.items_inserted, (0, 1, [e_obj]), path=(PathStep(index=0),)
+                root.events.batch_inserted, (0, 1, [e_obj]), path=(PathStep(index=0),)
             )
         ),
         call(EmissionInfo(e_obj.events.test2, ("hi",), path=(PathStep(index=0),))),
@@ -430,30 +430,30 @@ def test_contiguous_runs(indices: list[int], expected: list[tuple[int, int]]) ->
     assert list(_contiguous_runs(indices)) == expected
 
 
-def test_items_inserted_emits_once_for_batch():
+def test_batch_inserted_emits_once_for_batch():
     """The items_* batch signals fire once per contiguous block; per-item N times."""
     el = EventedList([0, 1, 2])
-    items_inserting = Mock()
-    items_inserted = Mock()
+    batch_inserting = Mock()
+    batch_inserted = Mock()
     inserted = Mock()
-    el.events.items_inserting.connect(items_inserting)
-    el.events.items_inserted.connect(items_inserted)
+    el.events.batch_inserting.connect(batch_inserting)
+    el.events.batch_inserted.connect(batch_inserted)
     el.events.inserted.connect(inserted)
 
     el.extend([3, 4, 5])
     assert el == [0, 1, 2, 3, 4, 5]
     # batch signal fires exactly once over the whole contiguous range...
-    items_inserting.assert_called_once_with(3, 6)
-    items_inserted.assert_called_once_with(3, 6, [3, 4, 5])
+    batch_inserting.assert_called_once_with(3, 6)
+    batch_inserted.assert_called_once_with(3, 6, [3, 4, 5])
     # ...while the per-item signal still fires once per item (unchanged contract)
     assert inserted.call_args_list == [call(3, 3), call(4, 4), call(5, 5)]
 
     # a single insert is just a length-1 range
-    items_inserting.reset_mock()
-    items_inserted.reset_mock()
+    batch_inserting.reset_mock()
+    batch_inserted.reset_mock()
     el.insert(0, 99)
-    items_inserting.assert_called_once_with(0, 1)
-    items_inserted.assert_called_once_with(0, 1, [99])
+    batch_inserting.assert_called_once_with(0, 1)
+    batch_inserted.assert_called_once_with(0, 1, [99])
 
 
 def test_per_item_signals_unchanged():
@@ -491,28 +491,28 @@ def test_insert_index_parity(index):
     assert el == ref
 
 
-def test_items_removed_emits_per_block():
+def test_batch_removed_emits_per_block():
     """Contiguous removals emit one block; non-contiguous emit once per block."""
     el = EventedList([0, 1, 2, 3, 4, 5])
-    items_removing = Mock()
-    items_removed = Mock()
-    el.events.items_removing.connect(items_removing)
-    el.events.items_removed.connect(items_removed)
+    batch_removing = Mock()
+    batch_removed = Mock()
+    el.events.batch_removing.connect(batch_removing)
+    el.events.batch_removed.connect(batch_removed)
 
     # contiguous slice -> single block
     del el[1:4]
     assert el == [0, 4, 5]
-    items_removing.assert_called_once_with(1, 4)
-    items_removed.assert_called_once_with(1, 4, [1, 2, 3])
+    batch_removing.assert_called_once_with(1, 4)
+    batch_removed.assert_called_once_with(1, 4, [1, 2, 3])
 
     # non-contiguous slice -> one block per contiguous run, highest first
     el[:] = [0, 1, 2, 3, 4, 5]
-    items_removing.reset_mock()
-    items_removed.reset_mock()
+    batch_removing.reset_mock()
+    batch_removed.reset_mock()
     del el[::2]  # indices 0, 2, 4
     assert el == [1, 3, 5]
-    assert items_removing.call_args_list == [call(4, 5), call(2, 3), call(0, 1)]
-    assert items_removed.call_args_list == [
+    assert batch_removing.call_args_list == [call(4, 5), call(2, 3), call(0, 1)]
+    assert batch_removed.call_args_list == [
         call(4, 5, [4]),
         call(2, 3, [2]),
         call(0, 1, [0]),
@@ -522,17 +522,17 @@ def test_items_removed_emits_per_block():
 def test_clear_emits_single_block():
     """clear() removes the whole list as one bracketed block."""
     el = EventedList([0, 1, 2, 3])
-    items_removing = Mock()
-    items_removed = Mock()
+    batch_removing = Mock()
+    batch_removed = Mock()
     removed = Mock()
-    el.events.items_removing.connect(items_removing)
-    el.events.items_removed.connect(items_removed)
+    el.events.batch_removing.connect(batch_removing)
+    el.events.batch_removed.connect(batch_removed)
     el.events.removed.connect(removed)
 
     el.clear()
     assert el == []
-    items_removing.assert_called_once_with(0, 4)
-    items_removed.assert_called_once_with(0, 4, [0, 1, 2, 3])
+    batch_removing.assert_called_once_with(0, 4)
+    batch_removed.assert_called_once_with(0, 4, [0, 1, 2, 3])
     # per-item still fires for each, highest index first (unchanged from before)
     assert removed.call_args_list == [call(3, 3), call(2, 2), call(1, 1), call(0, 0)]
 
@@ -542,14 +542,14 @@ def test_items_signals_drive_qt_style_model():
     el = EventedList([0, 1, 2])
     calls: list[tuple] = []
 
-    el.events.items_inserting.connect(
+    el.events.batch_inserting.connect(
         lambda start, stop: calls.append(("beginInsertRows", start, stop - 1))
     )
-    el.events.items_inserted.connect(lambda *_: calls.append(("endInsertRows",)))
-    el.events.items_removing.connect(
+    el.events.batch_inserted.connect(lambda *_: calls.append(("endInsertRows",)))
+    el.events.batch_removing.connect(
         lambda start, stop: calls.append(("beginRemoveRows", start, stop - 1))
     )
-    el.events.items_removed.connect(lambda *_: calls.append(("endRemoveRows",)))
+    el.events.batch_removed.connect(lambda *_: calls.append(("endRemoveRows",)))
 
     el.extend([3, 4])  # a single bracketed block for the whole batch
     del el[0:2]

--- a/tests/containers/test_evented_list.py
+++ b/tests/containers/test_evented_list.py
@@ -8,6 +8,7 @@ import pytest
 
 from psygnal import EmissionInfo, PathStep, Signal, SignalGroup
 from psygnal.containers import EventedList
+from psygnal.containers._evented_list import _contiguous_runs
 
 
 @pytest.fixture
@@ -411,6 +412,22 @@ def test_copy_no_sync():
     l2 = copy(l1)
     l1.append(4)
     assert len(l2) == 3
+
+
+@pytest.mark.parametrize(
+    "indices, expected",
+    [
+        ([], []),  # empty -> no runs
+        ([3], [(3, 4)]),
+        ([1, 2, 3], [(1, 4)]),  # single contiguous block
+        ([3, 1, 2], [(1, 4)]),  # unsorted input
+        ([1, 1, 2], [(1, 3)]),  # duplicates collapsed
+        ([0, 2, 4], [(4, 5), (2, 3), (0, 1)]),  # non-contiguous, highest first
+        ([1, 2, 3, 5, 6], [(5, 7), (1, 4)]),
+    ],
+)
+def test_contiguous_runs(indices: list[int], expected: list[tuple[int, int]]) -> None:
+    assert list(_contiguous_runs(indices)) == expected
 
 
 def test_items_inserted_emits_once_for_batch():

--- a/tests/containers/test_evented_list.py
+++ b/tests/containers/test_evented_list.py
@@ -1,4 +1,5 @@
 import os
+import pickle
 from copy import copy
 from typing import Any, cast
 from unittest.mock import Mock, call
@@ -607,3 +608,58 @@ def test_insert_emits_nothing_if_pre_insert_raises():
     el.insert(1, 9)
     assert tuple(received) == INSERT
     assert el == [0, 9, 1]
+
+
+def test_extend_calls_append_override():
+    """`extend` must keep funneling through `append`, as MutableSequence does."""
+
+    class MyList(EventedList):
+        def __init__(self, *args, **kwargs):
+            self.appended: list[Any] = []
+            super().__init__(*args, **kwargs)
+
+        def append(self, value: Any) -> None:
+            self.appended.append(value)
+            super().append(value)
+
+    el = MyList([0])
+    el.extend([1, 2])
+    el += [3]
+    assert el.appended == [0, 1, 2, 3]
+    assert el == [0, 1, 2, 3]
+
+
+def test_extend_appends_despite_reentrant_insert():
+    """A callback inserting mid-extend must not scramble the extended items."""
+    el = EventedList([0, 1])
+
+    def _on_inserted(index: int, value: Any) -> None:
+        if value == "a":
+            el.insert(0, "X")
+
+    el.events.inserted.connect(_on_inserted)
+    el.extend(["a", "b", "c"])
+    assert el == ["X", 0, 1, "a", "b", "c"]
+
+
+def test_unpickle_without_batch_depth():
+    """Instances pickled before `_batch_depth` existed must still be mutable."""
+    el = EventedList([1, 2])
+    el.__dict__.pop("_batch_depth", None)  # simulate a pickle from an older version
+    el2 = pickle.loads(pickle.dumps(el))
+    el2.append(3)
+    el2.extend([4])
+    assert el2 == [1, 2, 3, 4]
+
+
+@pytest.mark.parametrize("key", [5, 100, -6, -100])
+def test_delitem_out_of_range(key: int):
+    """Out-of-range deletes raise before emitting (no unpaired batch_removing)."""
+    el = EventedList([0, 1, 2, 3, 4])
+    received: list[str] = []
+    el.events.connect(lambda info: received.append(info.signal.name))
+
+    with pytest.raises(IndexError, match="out of range"):
+        del el[key]
+    assert received == []
+    assert el == [0, 1, 2, 3, 4]

--- a/tests/containers/test_evented_list.py
+++ b/tests/containers/test_evented_list.py
@@ -1,5 +1,4 @@
 import os
-import pickle
 from copy import copy
 from typing import Any, cast
 from unittest.mock import Mock, call
@@ -642,14 +641,13 @@ def test_extend_appends_despite_reentrant_insert():
     assert el == ["X", 0, 1, "a", "b", "c"]
 
 
-def test_unpickle_without_batch_depth():
-    """Instances pickled before `_batch_depth` existed must still be mutable."""
+def test_mutable_without_instance_batch_depth():
+    """Instances lacking `_batch_depth` (e.g. unpickled from older versions) work."""
     el = EventedList([1, 2])
-    el.__dict__.pop("_batch_depth", None)  # simulate a pickle from an older version
-    el2 = pickle.loads(pickle.dumps(el))
-    el2.append(3)
-    el2.extend([4])
-    assert el2 == [1, 2, 3, 4]
+    el.__dict__.pop("_batch_depth", None)  # as restored from an older pickle
+    el.append(3)
+    el.extend([4])
+    assert el == [1, 2, 3, 4]
 
 
 @pytest.mark.parametrize("key", [5, 100, -6, -100])

--- a/tests/containers/test_evented_list.py
+++ b/tests/containers/test_evented_list.py
@@ -22,53 +22,66 @@ def test_list(regular_list):
     return test_list
 
 
+# per-item events bracketed by the contiguous-block items_* events
+INSERT = ("items_inserting", "inserting", "inserted", "items_inserted")
+REMOVE = ("items_removing", "removing", "removed", "items_removed")
+
+
+def _remove_block(n: int) -> tuple[str, ...]:
+    # one contiguous block of N removals:
+    # items_removing, (removing, removed)*N, items_removed
+    return ("items_removing", *(("removing", "removed") * n), "items_removed")
+
+
+REMOVE_BLOCK2 = _remove_block(2)
+
+
 @pytest.mark.parametrize(
     "meth",
     [
         # METHOD, ARGS, EXPECTED EVENTS
         # primary interface
-        ("insert", (2, 10), ("inserting", "inserted")),  # create
+        ("insert", (2, 10), INSERT),  # create
         ("__getitem__", (2,), ()),  # read
         ("__setitem__", (2, 3), ("changed",)),  # update
         ("__setitem__", (slice(2), [1, 2]), ("changed",)),  # update slice
         ("__setitem__", (slice(2, 2), [1, 2]), ("changed",)),  # update slice
-        ("__delitem__", (2,), ("removing", "removed")),  # delete
-        (
-            "__delitem__",
-            (slice(2),),
-            ("removing", "removed") * 2,
-        ),
-        ("__delitem__", (slice(0, 0),), ("removing", "removed")),
-        (
-            "__delitem__",
-            (slice(-3),),
-            ("removing", "removed") * 2,
-        ),
-        (
-            "__delitem__",
-            (slice(-2, None),),
-            ("removing", "removed") * 2,
-        ),
+        ("__delitem__", (2,), REMOVE),  # delete
+        ("__delitem__", (slice(2),), REMOVE_BLOCK2),  # contiguous block
+        ("__delitem__", (slice(0, 0),), ()),  # empty slice -> no emission
+        ("__delitem__", (slice(-3),), REMOVE_BLOCK2),
+        ("__delitem__", (slice(-2, None),), REMOVE_BLOCK2),
+        # non-contiguous removal -> one bracketed block per contiguous run
+        ("__delitem__", (slice(None, None, 2),), REMOVE * 3),
         # inherited interface
-        ("append", (3,), ("inserting", "inserted")),
-        ("clear", (), ("removing", "removed") * 5),
+        ("append", (3,), INSERT),
+        ("clear", (), _remove_block(5)),  # whole list removed as one block
         ("count", (3,), ()),
-        ("extend", ([7, 8, 9],), ("inserting", "inserted") * 3),
+        (
+            "extend",
+            ([7, 8, 9],),
+            ("items_inserting", *(("inserting", "inserted") * 3), "items_inserted"),
+        ),
         ("index", (3,), ()),
-        ("pop", (-2,), ("removing", "removed")),
-        ("remove", (3,), ("removing", "removed")),
+        ("pop", (-2,), REMOVE),
+        ("remove", (3,), REMOVE),
         ("reverse", (), ("reordered",)),
-        ("__add__", ([7, 8, 9],), ()),
-        ("__iadd__", ([7, 9],), ("inserting", "inserted") * 2),
-        ("__radd__", ([7, 9],), ("inserting", "inserted") * 2),
+        ("__add__", ([7, 8, 9],), ()),  # operates on a copy
+        (
+            "__iadd__",
+            ([7, 9],),
+            ("items_inserting", *(("inserting", "inserted") * 2), "items_inserted"),
+        ),
+        ("__radd__", ([7, 9],), ()),  # does not mutate self
         # sort?
     ],
     ids=lambda x: x[0],
 )
 def test_list_interface_parity(test_list, regular_list, meth):
-    test_list.events = cast("Mock", test_list.events)
-
     method_name, args, expected = meth
+    received: list[str] = []
+    test_list.events.connect(lambda info: received.append(info.signal.name))
+
     test_list_method = getattr(test_list, method_name)
     assert tuple(test_list) == tuple(regular_list)
     if hasattr(regular_list, method_name):
@@ -78,9 +91,7 @@ def test_list_interface_parity(test_list, regular_list, meth):
     else:
         test_list_method(*args)  # smoke test
 
-    for c, expect in zip(test_list.events.call_args_list, expected, strict=False):
-        event = c.args[0]
-        assert event.type == expect
+    assert tuple(received) == expected
 
 
 def test_delete(test_list):
@@ -319,11 +330,20 @@ def test_child_events():
     assert root == [e_obj]
     e_obj.test.emit("hi")
 
-    assert mock.call_count == 3
+    # items_inserting + inserting + inserted + items_inserted + the child event
+    assert mock.call_count == 5
 
     expected = [
+        call(
+            EmissionInfo(root.events.items_inserting, (0, 1), path=(PathStep(index=0),))
+        ),
         call(EmissionInfo(root.events.inserting, (0,), path=(PathStep(index=0),))),
         call(EmissionInfo(root.events.inserted, (0, e_obj), path=(PathStep(index=0),))),
+        call(
+            EmissionInfo(
+                root.events.items_inserted, (0, 1, [e_obj]), path=(PathStep(index=0),)
+            )
+        ),
         call(
             EmissionInfo(
                 e_obj.test, ("hi",), path=(PathStep(index=0), PathStep(attr="test"))
@@ -357,16 +377,26 @@ def test_child_events_groups():
     e_obj.events.test2.emit("hi")
 
     assert [c[0][0].signal.name for c in mock.call_args_list] == [
+        "items_inserting",
         "inserting",
         "inserted",
+        "items_inserted",
         "test2",  # This is now the direct child signal, not child_event
     ]
 
     # when an object in the list owns an emitter group, then any emitter in that group
     # will also be detected, and the child event will be emitted directly with path info
     expected = [
+        call(
+            EmissionInfo(root.events.items_inserting, (0, 1), path=(PathStep(index=0),))
+        ),
         call(EmissionInfo(root.events.inserting, (0,), path=(PathStep(index=0),))),
         call(EmissionInfo(root.events.inserted, (0, e_obj), path=(PathStep(index=0),))),
+        call(
+            EmissionInfo(
+                root.events.items_inserted, (0, 1, [e_obj]), path=(PathStep(index=0),)
+            )
+        ),
         call(EmissionInfo(e_obj.events.test2, ("hi",), path=(PathStep(index=0),))),
     ]
 
@@ -381,3 +411,135 @@ def test_copy_no_sync():
     l2 = copy(l1)
     l1.append(4)
     assert len(l2) == 3
+
+
+def test_items_inserted_emits_once_for_batch():
+    """The items_* batch signals fire once per contiguous block; per-item N times."""
+    el = EventedList([0, 1, 2])
+    items_inserting = Mock()
+    items_inserted = Mock()
+    inserted = Mock()
+    el.events.items_inserting.connect(items_inserting)
+    el.events.items_inserted.connect(items_inserted)
+    el.events.inserted.connect(inserted)
+
+    el.extend([3, 4, 5])
+    assert el == [0, 1, 2, 3, 4, 5]
+    # batch signal fires exactly once over the whole contiguous range...
+    items_inserting.assert_called_once_with(3, 6)
+    items_inserted.assert_called_once_with(3, 6, [3, 4, 5])
+    # ...while the per-item signal still fires once per item (unchanged contract)
+    assert inserted.call_args_list == [call(3, 3), call(4, 4), call(5, 5)]
+
+    # a single insert is just a length-1 range
+    items_inserting.reset_mock()
+    items_inserted.reset_mock()
+    el.insert(0, 99)
+    items_inserting.assert_called_once_with(0, 1)
+    items_inserted.assert_called_once_with(0, 1, [99])
+
+
+def test_per_item_signals_unchanged():
+    """Legacy (index)/(index, value) callbacks behave exactly as before."""
+    el = EventedList([0, 1, 2])
+    inserting = Mock()
+    inserted = Mock()
+    removed = Mock()
+    el.events.inserting.connect(inserting)
+    el.events.inserted.connect(inserted)
+    el.events.removed.connect(removed)
+
+    el.append(9)
+    inserting.assert_called_once_with(3)
+    inserted.assert_called_once_with(3, 9)
+
+    # a batch still emits the per-item event for *every* item, not just once
+    inserting.reset_mock()
+    inserted.reset_mock()
+    el.extend([10, 11])
+    assert inserting.call_args_list == [call(4), call(5)]
+    assert inserted.call_args_list == [call(4, 10), call(5, 11)]
+
+    del el[0]
+    removed.assert_called_once_with(0, 0)
+
+
+@pytest.mark.parametrize("index", [-100, -2, -1, 0, 1, 2, 100])
+def test_insert_index_parity(index):
+    """insert() with negative/out-of-range indices matches builtin list."""
+    el = EventedList([0, 1, 2])
+    ref = [0, 1, 2]
+    el.insert(index, 9)
+    ref.insert(index, 9)
+    assert el == ref
+
+
+def test_items_removed_emits_per_block():
+    """Contiguous removals emit one block; non-contiguous emit once per block."""
+    el = EventedList([0, 1, 2, 3, 4, 5])
+    items_removing = Mock()
+    items_removed = Mock()
+    el.events.items_removing.connect(items_removing)
+    el.events.items_removed.connect(items_removed)
+
+    # contiguous slice -> single block
+    del el[1:4]
+    assert el == [0, 4, 5]
+    items_removing.assert_called_once_with(1, 4)
+    items_removed.assert_called_once_with(1, 4, [1, 2, 3])
+
+    # non-contiguous slice -> one block per contiguous run, highest first
+    el[:] = [0, 1, 2, 3, 4, 5]
+    items_removing.reset_mock()
+    items_removed.reset_mock()
+    del el[::2]  # indices 0, 2, 4
+    assert el == [1, 3, 5]
+    assert items_removing.call_args_list == [call(4, 5), call(2, 3), call(0, 1)]
+    assert items_removed.call_args_list == [
+        call(4, 5, [4]),
+        call(2, 3, [2]),
+        call(0, 1, [0]),
+    ]
+
+
+def test_clear_emits_single_block():
+    """clear() removes the whole list as one bracketed block."""
+    el = EventedList([0, 1, 2, 3])
+    items_removing = Mock()
+    items_removed = Mock()
+    removed = Mock()
+    el.events.items_removing.connect(items_removing)
+    el.events.items_removed.connect(items_removed)
+    el.events.removed.connect(removed)
+
+    el.clear()
+    assert el == []
+    items_removing.assert_called_once_with(0, 4)
+    items_removed.assert_called_once_with(0, 4, [0, 1, 2, 3])
+    # per-item still fires for each, highest index first (unchanged from before)
+    assert removed.call_args_list == [call(3, 3), call(2, 2), call(1, 1), call(0, 0)]
+
+
+def test_items_signals_drive_qt_style_model():
+    """items_* (start, stop) ranges wire directly onto begin/end{Insert,Remove}Rows."""
+    el = EventedList([0, 1, 2])
+    calls: list[tuple] = []
+
+    el.events.items_inserting.connect(
+        lambda start, stop: calls.append(("beginInsertRows", start, stop - 1))
+    )
+    el.events.items_inserted.connect(lambda *_: calls.append(("endInsertRows",)))
+    el.events.items_removing.connect(
+        lambda start, stop: calls.append(("beginRemoveRows", start, stop - 1))
+    )
+    el.events.items_removed.connect(lambda *_: calls.append(("endRemoveRows",)))
+
+    el.extend([3, 4])  # a single bracketed block for the whole batch
+    del el[0:2]
+
+    assert calls == [
+        ("beginInsertRows", 3, 4),  # inclusive last row, as Qt expects
+        ("endInsertRows",),
+        ("beginRemoveRows", 0, 1),
+        ("endRemoveRows",),
+    ]

--- a/tests/containers/test_evented_list.py
+++ b/tests/containers/test_evented_list.py
@@ -1,6 +1,6 @@
 import os
 from copy import copy
-from typing import cast
+from typing import Any, cast
 from unittest.mock import Mock, call
 
 import numpy as np
@@ -23,7 +23,7 @@ def test_list(regular_list):
     return test_list
 
 
-# per-item events bracketed by the contiguous-block items_* events
+# per-item events bracketed by the contiguous-block batch_* events
 INSERT = ("batch_inserting", "inserting", "inserted", "batch_inserted")
 REMOVE = ("batch_removing", "removing", "removed", "batch_removed")
 
@@ -431,7 +431,7 @@ def test_contiguous_runs(indices: list[int], expected: list[tuple[int, int]]) ->
 
 
 def test_batch_inserted_emits_once_for_batch():
-    """The items_* batch signals fire once per contiguous block; per-item N times."""
+    """The batch_* signals fire once per contiguous block; per-item N times."""
     el = EventedList([0, 1, 2])
     batch_inserting = Mock()
     batch_inserted = Mock()
@@ -537,8 +537,8 @@ def test_clear_emits_single_block():
     assert removed.call_args_list == [call(3, 3), call(2, 2), call(1, 1), call(0, 0)]
 
 
-def test_items_signals_drive_qt_style_model():
-    """items_* (start, stop) ranges wire directly onto begin/end{Insert,Remove}Rows."""
+def test_batch_signals_drive_qt_style_model():
+    """batch_* (start, stop) ranges wire directly onto begin/end{Insert,Remove}Rows."""
     el = EventedList([0, 1, 2])
     calls: list[tuple] = []
 
@@ -560,3 +560,50 @@ def test_items_signals_drive_qt_style_model():
         ("beginRemoveRows", 0, 1),
         ("endRemoveRows",),
     ]
+
+
+def test_subclass_insert_override_still_called_by_extend():
+    """`extend`/`+=`/`__init__` must keep funneling through the public `insert`."""
+
+    class MyList(EventedList):
+        def __init__(self, *args, **kwargs):
+            self.seen: list[tuple[int, Any]] = []
+            super().__init__(*args, **kwargs)
+
+        def insert(self, index: int, value: Any) -> None:
+            self.seen.append((index, value))
+            super().insert(index, value)
+
+    el = MyList([0, 1])  # __init__ extends
+    assert el.seen == [(0, 0), (1, 1)]
+
+    el.extend([2, 3])
+    assert el.seen[-2:] == [(2, 2), (3, 3)]
+
+    el += [4]
+    assert el.seen[-1] == (4, 4)
+    assert el == [0, 1, 2, 3, 4]
+
+
+def test_insert_emits_nothing_if_pre_insert_raises():
+    """A rejected value must not leave an unterminated `batch_inserting` behind."""
+
+    class Validated(EventedList):
+        def _pre_insert(self, value: Any) -> Any:
+            if not isinstance(value, int):
+                raise TypeError("ints only")
+            return value
+
+    el = Validated([0, 1])
+    received: list[str] = []
+    el.events.connect(lambda info: received.append(info.signal.name))
+
+    with pytest.raises(TypeError, match="ints only"):
+        el.insert(1, "nope")
+    assert received == []  # not even batch_inserting
+    assert el == [0, 1]
+
+    # and the batch signals stay paired on the success path
+    el.insert(1, 9)
+    assert tuple(received) == INSERT
+    assert el == [0, 9, 1]


### PR DESCRIPTION
playing with explicit support of batch signals, re #419 