### PR TITLE
fix: Improve disconnect behavior for slots with missing_ok option in SignalRelay

### DIFF
--- a/src/psygnal/_group.py
+++ b/src/psygnal/_group.py
@@ -314,9 +314,16 @@ class SignalRelay(SignalInstance):
         ValueError
             If `slot` is not connected and `missing_ok` is False.
         """
+        # A slot may be connected either to the relay itself (via `group.connect`)
+        # or directly to the child signals (via `group.connect_direct`).  It is
+        # therefore "connected" as long as it is found in any of those places, so
+        # we must not enforce `missing_ok` on each child individually.
+        if slot is not None and not missing_ok and slot not in self:
+            if not any(slot in sig for sig in self._signals.values()):
+                raise ValueError(f"slot is not connected: {slot}")
         for sig in self._signals.values():
-            sig.disconnect(slot, missing_ok)
-        super().disconnect(slot, missing_ok)
+            sig.disconnect(slot, missing_ok=True)
+        super().disconnect(slot, missing_ok=True)
 
     def _slot_index(self, slot: Callable) -> int:
         """Get index of `slot` in `self._slots`. Return -1 if not connected.

--- a/tests/test_group.py
+++ b/tests/test_group.py
@@ -209,6 +209,46 @@ def test_group_disconnect_all_slots() -> None:
     mock2.assert_not_called()
 
 
+def test_group_disconnect_relay_slot_missing_ok() -> None:
+    """A slot connected to the group can be disconnected with `missing_ok=False`.
+
+    See https://github.com/pyapp-kit/psygnal/issues/425
+    """
+    group = MyGroup()
+    mock = Mock()
+
+    group.connect(mock)
+    # should not raise: the slot is connected to the relay, not the child signals
+    group.disconnect(mock, missing_ok=False)
+
+    group.sig1.emit(1)
+    mock.assert_not_called()
+
+    # a genuinely-missing slot still raises with missing_ok=False
+    with pytest.raises(ValueError, match="slot is not connected"):
+        group.disconnect(mock, missing_ok=False)
+
+
+def test_group_disconnect_direct_slot_missing_ok() -> None:
+    """A `connect_direct` slot can also be disconnected with `missing_ok=False`.
+
+    See https://github.com/pyapp-kit/psygnal/issues/425
+    """
+    group = MyGroup()
+    mock = Mock()
+
+    group.connect_direct(mock)
+    # `connect_direct` puts the slot on the child signals, not the relay
+    group.disconnect(mock, missing_ok=False)
+
+    group.sig1.emit(1)
+    mock.assert_not_called()
+
+    # a genuinely-missing slot still raises with missing_ok=False
+    with pytest.raises(ValueError, match="slot is not connected"):
+        group.disconnect(mock, missing_ok=False)
+
+
 def test_weakref() -> None:
     """Make sure that the group doesn't keep a strong reference to the instance."""
     import gc


### PR DESCRIPTION
fixes #425