### PR TITLE
fix: preserve defaults in empty model subclasses

### DIFF
--- a/src/psygnal/_evented_model.py
+++ b/src/psygnal/_evented_model.py
@@ -168,9 +168,16 @@ class EventedMetaclass(pydantic_main.ModelMetaclass):
         mcs: type, name: str, bases: tuple, namespace: dict, **kwargs: Any
     ) -> "EventedMetaclass":
         """Create new EventedModel class."""
-        # Pydantic uses the absence of __annotations__ differently from an
-        # explicitly empty mapping when rebuilding inherited fields.
-        namespace.setdefault("__annotations__", {})
+        # Pydantic uses an absent __annotations__ differently from an empty
+        # mapping when rebuilding inherited fields. Python 3.14 may instead
+        # provide lazy annotations through its class-body __annotate_func__;
+        # do not mask those (or a metaclass-provided __annotate__).
+        if not {
+            "__annotations__",
+            "__annotate__",
+            "__annotate_func__",
+        }.intersection(namespace):
+            namespace["__annotations__"] = {}
         with no_class_attributes():
             cls = super().__new__(mcs, name, bases, namespace, **kwargs)
 

--- a/src/psygnal/_evented_model.py
+++ b/src/psygnal/_evented_model.py
@@ -168,6 +168,9 @@ class EventedMetaclass(pydantic_main.ModelMetaclass):
         mcs: type, name: str, bases: tuple, namespace: dict, **kwargs: Any
     ) -> "EventedMetaclass":
         """Create new EventedModel class."""
+        # Pydantic uses the absence of __annotations__ differently from an
+        # explicitly empty mapping when rebuilding inherited fields.
+        namespace.setdefault("__annotations__", {})
         with no_class_attributes():
             cls = super().__new__(mcs, name, bases, namespace, **kwargs)
 

--- a/tests/test_evented_model.py
+++ b/tests/test_evented_model.py
@@ -34,6 +34,21 @@ def test_creating_empty_evented_model():
     assert model.events is not None
 
 
+def test_empty_subclass_preserves_inherited_field_defaults():
+    """An annotation-free subclass must retain its inherited defaults."""
+
+    class Parent(EventedModel):
+        count: int = 1
+        label: str = "default"
+
+    class EmptySubclass(Parent):
+        pass
+
+    model = EmptySubclass()
+    assert model.count == 1
+    assert model.label == "default"
+
+
 def test_evented_model():
     """Test creating an evented pydantic model."""
 

--- a/tests/test_evented_model.py
+++ b/tests/test_evented_model.py
@@ -49,6 +49,16 @@ def test_empty_subclass_preserves_inherited_field_defaults():
     assert model.label == "default"
 
 
+def test_empty_subclass_fix_preserves_annotated_fields():
+    """Lazy annotations must not be replaced by an empty mapping."""
+
+    class Annotated(EventedModel):
+        count: int = 1
+
+    assert Annotated().count == 1
+    assert "count" in Annotated.model_fields
+
+
 def test_evented_model():
     """Test creating an evented pydantic model."""
 


### PR DESCRIPTION
Ensures annotation-free `EventedModel` subclasses keep inherited field defaults under Pydantic 2.14.

Fixes #417

Tests: 693 passed on Pydantic 2.13.5; 34 passed on 2.14.0a1. Ruff passes.
