### PR TITLE
build: revert debug_level=0, document the real reproducible-builds fix

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,7 +100,18 @@ sources = ["src"]
 
 [tool.hatch.build.targets.wheel.hooks.mypyc]
 mypy-args = ["--ignore-missing-imports"]
-options = { debug_level = "0" }
+# NOTE: do not set `options.debug_level = "0"` here to "fix" reproducible builds
+# (see #421/#429). It works, but it strips C debug symbols from every wheel we
+# ship, which downstream packagers who build -dbgsym packages (e.g. Debian) need
+# and have to explicitly restore. The actual source of non-determinism is
+# hatch-mypyc's default `tempfile.TemporaryDirectory()` build root, which embeds
+# a random path into the compiled .so's debug info on every build. Debian's own
+# packaging already fixes this correctly, without touching debug_level, by
+# pointing `HATCH_MYPYC_BUILD_DIR` at a fixed, pre-created directory instead of
+# the random default (see debian/rules), combined with dpkg's default
+# `-ffile-prefix-map` (the `fixfilepath` build flag) to normalize the remaining
+# absolute-build-root prefix. Confirmed locally: with a fixed `build-dir` alone
+# (no debug_level change), two separate builds embed byte-identical paths.
 enable-by-default = false
 require-runtime-dependencies = true
 dependencies = [


### PR DESCRIPTION
Reopens #421 — mr-c [confirmed](https://github.com/pyapp-kit/psygnal/issues/421#issuecomment-5634910614) that #429's fix (`debug_level = "0"`) strips C debug symbols entirely, which Debian's `-dbgsym` packaging needs and will have to explicitly revert on their side.

## What this does

Reverts `options = { debug_level = "0" }`, restoring mypyc's default (debug info present), and replaces it with a comment explaining the actual fix and why `debug_level=0` shouldn't be reintroduced.

## Why this is safe / what the real problem was

The non-reproducibility isn't from disabling `-g0` — it's from hatch-mypyc building inside a fresh `tempfile.TemporaryDirectory()` every time, so the random path gets embedded in the compiled `.so`'s debug info. `debug_level=0` "fixed" it only by removing debug info altogether.

Debian's own packaging (`debian/rules`, added in 0.15.1-3 by Colin Watson, independent of anything in this repo) fixes the actual cause instead: it points `HATCH_MYPYC_BUILD_DIR` at a fixed, pre-created directory, combined with dpkg's default `-ffile-prefix-map`. [tests.reproducible-builds.org currently shows psygnal as reproducible](https://tests.reproducible-builds.org/debian/rb-pkg/unstable/amd64/psygnal.html) as a result — with debug info intact.

I verified this locally (macOS, default `debug_level`): two separate builds from the same project root, with `HATCH_MYPYC_BUILD_DIR` fixed and pre-created, embed byte-identical paths in the compiled `.so`. Full writeup with the details in [the issue comment](https://github.com/pyapp-kit/psygnal/issues/421).

## Verification
- Compiled build (mypyc, default debug_level) on py3.14: 735 passed, 8 skipped
- `prek run --files pyproject.toml`: passed
- Wheel size goes back up by the ~11% #429 saved (debug info restored) — no other size/behavior impact

## Not included here
Wiring `HATCH_MYPYC_BUILD_DIR` into our own release CI so our published wheels are byte-reproducible too. cibuildwheel builds each platform in its own container/venv and I couldn't verify the container path is stable across runs from here, so I left it as a documented follow-up in the issue rather than shipping something untested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011J3gAnJNwqyWvosDvLwNPE

